### PR TITLE
ActionSheetManager typo & ListViewDataSource improvement

### DIFF
--- a/src/NativeModules/ActionSheetManager.js
+++ b/src/NativeModules/ActionSheetManager.js
@@ -3,7 +3,7 @@ const ActionSheetManager = {
   showActionSheetWithOptions(options, callback) {
 
   },
-  showShareActionSHeetWithOptions(options, failure, success) {
+  showShareActionSheetWithOptions(options, failure, success) {
 
   },
 };

--- a/src/api/ListViewDataSource.js
+++ b/src/api/ListViewDataSource.js
@@ -2,11 +2,18 @@
 
 class ListViewDataSource {
   constructor() {
-
+    this._dataBlob = null;
   }
 
   getRowCount() {
 
+  }
+
+  cloneWithRows(data) {
+    var newSource = new ListViewDataSource();
+    newSource._dataBlob = data;
+
+    return newSource;
   }
 }
 


### PR DESCRIPTION
This PR makes 2 changes:
1. It fixes a typo in `ActionSheetManager.showShareActionSHeetWithOptions` function name (S**H**eet → S**h**eet)
2. Adds `cloneWithRows` method to `ListViewDataSource` that imitates the original method (except for sections and rows stuff).
