### PR TITLE
Lowercase keyMirror dependency to match npm name

### DIFF
--- a/src/api/InteractionManager.js
+++ b/src/api/InteractionManager.js
@@ -1,4 +1,4 @@
-import keyMirror from 'keyMirror';
+import keyMirror from 'keymirror';
 import invariant from 'invariant';
 
 const { EventEmitter } = require('events');


### PR DESCRIPTION
Currently the build fails to find module 'keyMirror' on Travis and Linux, while passing on OSX.
