### PR TITLE
Fixed Linking modules not accepting handlers

### DIFF
--- a/src/NativeModules/LinkingManager.js
+++ b/src/NativeModules/LinkingManager.js
@@ -1,9 +1,9 @@
 let _test = url => true;
 const LinkingManger = {
-  openUrl(url) {
+  openURL(url) {
     return Promise.resolve(true);
   },
-  canOpenUrl(url) {
+  canOpenURL(url) {
     return Promise.resolve(_test(url));
   },
 

--- a/src/api/Linking.js
+++ b/src/api/Linking.js
@@ -1,6 +1,9 @@
 import invariant from 'invariant';
 import Platform from '../plugins/Platform';
 import DeviceEventEmitter from '../plugins/DeviceEventEmitter';
+import LinkingManager from '../NativeModules/LinkingManager';
+
+const _notifHandlers = new Map();
 
 const DEVICE_NOTIF_EVENT = 'openURL';
 
@@ -45,7 +48,10 @@ class Linking {
       if (!listener) {
         return;
       }
-      listener.remove();
+      listener.removeListener(
+          DEVICE_NOTIF_EVENT,
+          handler
+      );
       _notifHandlers.delete(handler);
     }
   }


### PR DESCRIPTION
Missing const, caused ReferenceError

Also corrected use of LinkingManager inside Linking
