### PR TITLE
Add NavigationExperimental

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-mock",
-  "version": "0.0.6",
+  "version": "0.0.8",
   "description": "A fully mocked and test-friendly version of react native",
   "main": "build/react-native.js",
   "scripts": {

--- a/src/react-native.js
+++ b/src/react-native.js
@@ -20,6 +20,7 @@ const ReactNative = {
   Modal: createMockComponent('Modal'),
   Navigator: require('./components/Navigator'),
   NavigatorIOS: createMockComponent('NavigatorIOS'),
+  NavigationExperimental: createMockComponent('NavigationExperimental'),
   Picker: createMockComponent('Picker'),
   PickerIOS: createMockComponent('PickerIOS'),
   ProgressBarAndroid: createMockComponent('ProgressBarAndroid'),


### PR DESCRIPTION
I had problems using Mocha + Enzyme with [react-native-router-flux](https://github.com/aksonov/react-native-router-flux) because it was missing NavigatorExperimental mocks.
