### PR TITLE
Fixes AsyncStorage set/get item if no callback is provided

### DIFF
--- a/src/api/AsyncStorage.js
+++ b/src/api/AsyncStorage.js
@@ -4,8 +4,8 @@
 
 function wrap(value, callback) {
   return Promise.resolve(value).then(
-    obj => callback(null, obj),
-    err => callback(err)
+    obj => callback && callback(null, obj),
+    err => callback && callback(err)
   );
 }
 


### PR DESCRIPTION
Hi @lelandrichardson ,
Given there is no activity on https://github.com/lelandrichardson/react-native-mock/pull/18 can we go on with this PR?

React documentation put the `AsyncStorage` callback [as optional](https://github.com/facebook/react-native/blob/master/Libraries/Storage/AsyncStorage.js#L72).

Using react-native-mock `AsyncStorage` without the callback would cause an error (`'undefined' is not a function`) that prevents the mock to work properly.
