### PR TITLE
Add mocked StatusBar component

### DIFF
--- a/src/components/StatusBar.js
+++ b/src/components/StatusBar.js
@@ -10,17 +10,17 @@ let _networkActivityIndicatorVisible = false;
 let _translucent = false;
 
 const StatusBar = React.createClass({
-  statics: {
-    propTypes: {
-      animated: React.PropTypes.bool,
-      barStyle: React.PropTypes.oneOf(['default', 'light-content']),
-      backgroundColor: React.PropTypes.bool,
-      hidden: React.PropTypes.bool,
-      networkActivityIndicatorVisible: React.PropTypes.bool,
-      showHideTransition: React.PropTypes.oneOf(['fade', 'slide']),
-      translucent: React.PropTypes.bool
-    },
+  propTypes: {
+    animated: React.PropTypes.bool,
+    barStyle: React.PropTypes.oneOf(['default', 'light-content']),
+    backgroundColor: React.PropTypes.bool,
+    hidden: React.PropTypes.bool,
+    networkActivityIndicatorVisible: React.PropTypes.bool,
+    showHideTransition: React.PropTypes.oneOf(['fade', 'slide']),
+    translucent: React.PropTypes.bool
+  },
 
+  statics: {
     setBackgroundColor(backgroundColor, animated) {
       _backgroundColor = backgroundColor;
     },

--- a/src/components/StatusBar.js
+++ b/src/components/StatusBar.js
@@ -1,0 +1,70 @@
+/**
+ * https://github.com/facebook/react-native/blob/master/Libraries/Components/StatusBar/StatusBar.js
+ */
+import React from 'react';
+
+let _backgroundColor = '';
+let _barStyle = {};
+let _hidden = false;
+let _networkActivityIndicatorVisible = false;
+let _translucent = false;
+
+const StatusBar = React.createClass({
+  statics: {
+    propTypes: {
+      animated: React.PropTypes.bool,
+      barStyle: React.PropTypes.oneOf(['default', 'light-content']),
+      backgroundColor: React.PropTypes.bool,
+      hidden: React.PropTypes.bool,
+      networkActivityIndicatorVisible: React.PropTypes.bool,
+      showHideTransition: React.PropTypes.oneOf(['fade', 'slide']),
+      translucent: React.PropTypes.bool
+    },
+
+    setBackgroundColor(backgroundColor, animated) {
+      _backgroundColor = backgroundColor;
+    },
+
+    setBarStyle(barStyle, animated) {
+      _barStyle = barStyle;
+    },
+
+    setHidden(hidden, animated) {
+      _hidden = hidden;
+    },
+
+    setNetworkActivityIndicatorVisible(visible) {
+      _networkActivityIndicatorVisible = visible;
+    },
+
+    setTranslucent(translucent) {
+      _translucent = translucent;
+    },
+
+    __getBackgroundColor() {
+      return _backgroundColor;
+    },
+
+    __getBarStyle() {
+      return _barStyle;
+    },
+
+    __getHidden() {
+      return _hidden;
+    },
+
+    __getNetworkActivityIndicatorVisible() {
+      return _networkActivityIndicatorVisible;
+    },
+
+    __getTranslucent() {
+      return _translucent;
+    }
+  },
+
+  render() {
+    return null;
+  }
+})
+
+module.exports = StatusBar;

--- a/src/react-native.js
+++ b/src/react-native.js
@@ -32,6 +32,7 @@ const ReactNative = {
   PullToRefreshViewAndroid: createMockComponent('PullToRefreshViewAndroid'),
   RecyclerViewBackedScrollView: createMockComponent('RecyclerViewBackedScrollView'),
   RefreshControl: createMockComponent('RefreshControl'),
+  StatusBar: require('./components/StatusBar'),
   SwitchAndroid: createMockComponent('SwitchAndroid'),
   SwitchIOS: createMockComponent('SwitchIOS'),
   TabBarIOS: createMockComponent('TabBarIOS'),


### PR DESCRIPTION
## Why

The React Native team recently moved towards the `StatusBar` component (and imperative API) vs the `StatusBarIOS` API.
## What changed?
- Added a `StatusBar` component
- Mocked some static methods on `StatusBar`
