### PR TITLE
Add missing required default 'renderScrollComponent' prop for ListView

### DIFF
--- a/src/components/ListView.js
+++ b/src/components/ListView.js
@@ -167,6 +167,12 @@ const ListView = React.createClass({
     this.refs[SCROLLVIEW_REF].setNativeProps(props);
   },
 
+  getDefaultProps() {
+    return {
+      renderScrollComponent: (props) => <ScrollView {...props} />
+    };
+  },
+
   getInnerViewNode() {
     return this.refs[SCROLLVIEW_REF].getInnerViewNode();
   },


### PR DESCRIPTION
## Why?

This isn't a prop that I generally pass through to the `ListView` component (I generally want the default `ScrollView` component) and it was giving me warnings when running my tests:

> Warning: Failed propType: Required prop `renderScrollComponent` was not specified in `ListView`.
## What changed?
- Added the default prop configuration for `renderScrollComponent` that matches what is in the un-mocked RN code
