### PR TITLE
Ignore .babelrc through .npmignore to fix issue with react-native

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+.babelrc


### PR DESCRIPTION
Ignore .babelrc through .npmignore to fix issue with react-native packager.

The react-native packager searches through all directories and parses
.babelrc config files if it finds any. This breaks the builds if these
.babelrc files are either for babel 5 or if they contain plugins unknown
to the parent project.

@see: https://github.com/facebook/react-native/issues/4062
