### PR TITLE
Use the React version provided by peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "eslint-plugin-react": "=5.1.1",
     "eslint-plugin-react-native": "=1.0.2",
     "mocha": "=2.5.3",
+    "react": "=15.0.2",
     "react-native": "^0.26.0"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "invariant": "=2.2.1",
     "keymirror": "=0.1.1",
     "raf": "=3.2.0",
-    "react": "=15.0.2",
     "react-addons-create-fragment": "=15.0.2",
     "react-addons-linked-state-mixin": "=15.0.2",
     "react-addons-perf": "=15.0.2",


### PR DESCRIPTION
Use the React version provided by application through peerDependencies
instead of specifying an exact version ourselves.
The user needs to install React anyways to be able to use
JSX / React.createClass.
