### PR TITLE
Fix return value of AsyncStorage methods

### DIFF
--- a/src/api/AsyncStorage.js
+++ b/src/api/AsyncStorage.js
@@ -4,8 +4,14 @@
 
 function wrap(value, callback) {
   return Promise.resolve(value).then(
-    obj => callback && callback(null, obj),
-    err => callback && callback(err)
+    obj => {
+      callback && callback(null, obj);
+      return obj;
+    },
+    err => {
+      callback && callback(err);
+      throw err;
+    }
   );
 }
 


### PR DESCRIPTION
`AsyncStorage.getItem` and similar methods should return the item in the promise chain. Similarly, error should be propagated.

https://github.com/facebook/react-native/blob/4879f88a75204588fbe461ab43f8cd50a09dd707/Libraries/Storage/AsyncStorage.js
