### PR TITLE
Platform.select method

### DIFF
--- a/src/plugins/Platform.js
+++ b/src/plugins/Platform.js
@@ -11,7 +11,10 @@ const Platform = {
   __setOS(os) {
     Platform.OS = os;
   },
-
+  
+  select(objs) {
+    return objs.ios;
+  },
   /**
    * Exposed in react-native-mock for testing purposes. Not part of real API.
    */


### PR DESCRIPTION
Still getting TypeError: _reactNative.Platform.select is not a function error, not sure why..

https://github.com/facebook/react-native/pull/7220
