### PR TITLE
The item of the PickerIOS

### DIFF
--- a/src/react-native.js
+++ b/src/react-native.js
@@ -97,6 +97,7 @@ const ReactNative = {
   EdgeInsetsPropType: require('./propTypes/EdgeInsetsPropType'),
   PointPropType: require('./propTypes/PointPropType'),
 };
+  ReactNative.PickerIOS.Item = createMockComponent('PickerIOS.Item');
 
 // See http://facebook.github.io/react/docs/addons.html
 const ReactNativeAddons = {


### PR DESCRIPTION
fix the warning:
   React.createElement: type should not be null, undefined, boolean, or number. It should be a string (for DOM elements) or a ReactClass (for composite components).
