### PR TITLE
Do not require react-addons-perf

### DIFF
--- a/src/react-native.js
+++ b/src/react-native.js
@@ -101,7 +101,6 @@ const ReactNative = {
 // See http://facebook.github.io/react/docs/addons.html
 const ReactNativeAddons = {
   LinkedStateMixin: require('react-addons-linked-state-mixin'),
-  Perf: require('react-addons-perf'),
   PureRenderMixin: require('react-addons-pure-render-mixin'),
   TestModule: require('./NativeModules/TestModule'),
   TestUtils: require('react-addons-test-utils'),


### PR DESCRIPTION
This removes react-addons-perf which seems to be unavailable in 15.1, although someone who actually uses this should probably weigh in as it may have simply moved locations.

The specific observed error prompting this change was: `Error: Cannot find module 'react/lib/ReactDefaultPerf'`
