### PR TITLE
Implement Platform.select in the Mock

### DIFF
--- a/src/plugins/Platform.js
+++ b/src/plugins/Platform.js
@@ -12,6 +12,10 @@ const Platform = {
     Platform.OS = os;
   },
 
+  select(objs) {
+    return objs[Platform.OS];
+  },
+
   /**
    * Exposed in react-native-mock for testing purposes. Not part of real API.
    */


### PR DESCRIPTION
In order to test components with styling that leverages Platform.select,
react-native-mock should implement that function.

Replaces #61 
