### PR TITLE
Remove explicit use of `window`

### DIFF
--- a/src/api/Animated/AnimatedImplementation.js
+++ b/src/api/Animated/AnimatedImplementation.js
@@ -156,7 +156,9 @@ class TimingAnimation extends Animation {
   stop() {
     this.__active = false;
     clearTimeout(this._timeout);
-    window.cancelAnimationFrame(this._animationFrame);
+    if (window) {
+      window.cancelAnimationFrame(this._animationFrame); 
+    }
     this.__debouncedOnEnd({ finished: false });
   }
 }
@@ -201,7 +203,9 @@ class DecayAnimation extends Animation {
 
   stop() {
     this.__active = false;
-    window.cancelAnimationFrame(this._animationFrame);
+    if (window) {
+      window.cancelAnimationFrame(this._animationFrame);
+    }
     this.__debouncedOnEnd({ finished: false });
   }
 }

--- a/src/api/Animated/AnimatedImplementation.js
+++ b/src/api/Animated/AnimatedImplementation.js
@@ -156,8 +156,8 @@ class TimingAnimation extends Animation {
   stop() {
     this.__active = false;
     clearTimeout(this._timeout);
-    if (window) {
-      window.cancelAnimationFrame(this._animationFrame); 
+    if (global && global.cancelAnimationFrame) {
+      global.cancelAnimationFrame(this._animationFrame); 
     }
     this.__debouncedOnEnd({ finished: false });
   }
@@ -203,8 +203,8 @@ class DecayAnimation extends Animation {
 
   stop() {
     this.__active = false;
-    if (window) {
-      window.cancelAnimationFrame(this._animationFrame);
+    if (global && global.cancelAnimationFrame) {
+      global.cancelAnimationFrame(this._animationFrame);
     }
     this.__debouncedOnEnd({ finished: false });
   }

--- a/src/api/Animated/AnimatedImplementation.js
+++ b/src/api/Animated/AnimatedImplementation.js
@@ -157,7 +157,7 @@ class TimingAnimation extends Animation {
     this.__active = false;
     clearTimeout(this._timeout);
     if (global && global.cancelAnimationFrame) {
-      global.cancelAnimationFrame(this._animationFrame); 
+      global.cancelAnimationFrame(this._animationFrame);
     }
     this.__debouncedOnEnd({ finished: false });
   }


### PR DESCRIPTION
`Window` as a global doesnt exist when run under Node.JS. However, if run under something like `jsdom`, it does.

This PR allows window to be accessed if it exists, but stops anything breaking if it doesnt exist.

Should fix #69 
