### PR TITLE
Stop some things being published to NPM

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,6 @@
 .babelrc
+CONTRIBUTING.md
+.eslintrc
+.gitignore
+test/
+.travis.yml


### PR DESCRIPTION
NPM doesnt need to know about all our files, so let's stop pushing them up there. This isnt much use now, but will be once more tests are added etc.
