### PR TITLE
NavigatorExperimental: State should not have the new route

### DIFF
--- a/src/Libraries/NavigationExperimental/NavigationStateUtils.js
+++ b/src/Libraries/NavigationExperimental/NavigationStateUtils.js
@@ -11,7 +11,7 @@ function has(state, key) {
 }
 
 function push(state, route) {
-  if (indexOf(state, route.key) === -1) {
+  if (indexOf(state, route.key) !== -1) {
     throw new Error('should not push route with duplicated key ' + route.key);
   }
 


### PR DESCRIPTION
I pulled down master because wanted to mock `NavigatorExperimental`. Looks like there was a tiny error with the logic that was breaking my tests, so I went ahead and fixed it.
