### PR TITLE
fixed the check for duplicate route being pushed

### DIFF
--- a/src/Libraries/NavigationExperimental/NavigationStateUtils.js
+++ b/src/Libraries/NavigationExperimental/NavigationStateUtils.js
@@ -11,7 +11,7 @@ function has(state, key) {
 }
 
 function push(state, route) {
-  if (indexOf(state, route.key) === -1) {
+  if (indexOf(state, route.key) !== -1) {
     throw new Error('should not push route with duplicated key ' + route.key);
   }
 


### PR DESCRIPTION
Noticed that there is an issue with `NavigationStateUtils.push` method. In the original [react-native version](https://github.com/facebook/react-native/blob/master/Libraries/NavigationExperimental/NavigationStateUtils.js#L53) you will notice that it uses `invariant` check for `indexOf(state, route.key) === -1`:

``` js
function push(state: NavigationState, route: NavigationRoute): NavigationState {
  invariant(
    indexOf(state, route.key) === -1,
    'should not push route with duplicated key %s',
    route.key,
  );
...
}
```

Where as the react-native-mock version throws an error if `indexOf(state, route.key) === -1` is `true`:

``` js
function push(state, route) {
  if (indexOf(state, route.key) === -1) {
    throw new Error('should not push route with duplicated key ' + route.key);
  }
...
}
```

Invariant throws an error for falsy values (https://github.com/zertosh/invariant#invariantcondition-message). Therefore the above should be: `indexOf(state, route.key) !== -1`
