### PR TITLE
fix(EventEmitter): wrong variable name, linting issues

### DIFF
--- a/src/Libraries/EventEmitter/EventEmitter.js
+++ b/src/Libraries/EventEmitter/EventEmitter.js
@@ -50,7 +50,6 @@ class EventEmitter {
    *   listener
    */
   addListener(eventType, listener, context) {
-
     return (this._subscriber.addSubscription(
       eventType,
       new EmitterSubscription(this, this._subscriber, listener, context)
@@ -135,7 +134,7 @@ class EventEmitter {
    */
   listeners(eventType) {
     const subscriptions = (this._subscriber.getSubscriptionsForType(eventType));
-    return subscriptions ? subscriptions.map(s => subscription.listener) : [];
+    return subscriptions ? subscriptions.map(subscription => subscription.listener) : [];
   }
 
   /**

--- a/src/Libraries/EventEmitter/NativeEventEmitter.js
+++ b/src/Libraries/EventEmitter/NativeEventEmitter.js
@@ -1,5 +1,6 @@
 const invariant = require('invariant');
 const EventEmitter = require('./EventEmitter');
+const EmitterSubscription = require('./EmitterSubscription');
 const EventSubscriptionVender = require('./EventSubscriptionVendor');
 
 const sharedSubscriber = new EventSubscriptionVender();


### PR DESCRIPTION
This PR fixes linting issues and a wrong variable name. @lelandrichardson pls check if my assumption is correct and you just forget to double-check the code.
