### PR TITLE
Add mock for KeyboardAvoidingView

### DIFF
--- a/src/react-native.js
+++ b/src/react-native.js
@@ -16,6 +16,7 @@ const ReactNative = {
   Image: require('./components/Image'),
   ImageEditor: createMockComponent('ImageEditor'),
   ImageStore: createMockComponent('ImageStore'),
+  KeyboardAvoidingView: createMockComponent('KeyboardAvoidingView'),
   ListView: require('./components/ListView'),
   MapView: createMockComponent('MapView'),
   Modal: createMockComponent('Modal'),


### PR DESCRIPTION
with version 0.29 react-native introduced the KeyboardAvoidingView.
https://github.com/facebook/react-native/commit/8b78846a9501ef9c5ce9d1e18ee104bfae76af2e
https://github.com/facebook/react-native/releases/tag/v0.29.0
https://facebook.github.io/react-native/releases/next/docs/keyboardavoidingview.html
This commit adds a mock component with the same name, so that tests for
code that uses this view do not break.
