### PR TITLE
Add other Path methods to ART Path mock

### DIFF
--- a/src/components/ART/Path.js
+++ b/src/components/ART/Path.js
@@ -1,20 +1,25 @@
 
 class Path {
   constructor(path) {
+    [
+      'push',
+      'reset',
+      'move',
+      'moveTo',
+      'line',
+      'lineTo',
+      'curve',
+      'curveTo',
+      'arc',
+      'arcTo',
+      'counterArc',
+      'counterArcTo',
+      'close'
+    ].forEach((methodName) => { this[methodName] = () => this });
+
     this.path = path || [];
   }
-  move() {
-    return this;
-  }
-  moveTo() {
-    return this;
-  }
-  line() {
-    return this;
-  }
-  close() {
-    return this;
-  }
+
   toJSON() {
     return JSON.stringify(this.path);
   }

--- a/src/components/ART/Path.js
+++ b/src/components/ART/Path.js
@@ -15,7 +15,7 @@ class Path {
       'counterArc',
       'counterArcTo',
       'close'
-    ].forEach((methodName) => { this[methodName] = () => this });
+    ].forEach((methodName) => { this[methodName] = () => this; });
 
     this.path = path || [];
   }


### PR DESCRIPTION
This PR resolves issue #100 . It just adds the rest of the ART Path methods to the mock.
