### PR TITLE
Fix resolve value for get item of AsyncStorage

### DIFF
--- a/src/api/AsyncStorage.js
+++ b/src/api/AsyncStorage.js
@@ -23,7 +23,7 @@ let db = {};
 
 const AsyncStorage = {
   getItem(key, callback) {
-    return wrap(db[key], callback);
+    return wrap(db[key] || null, callback);
   },
 
   setItem(key, value, callback) {
@@ -55,7 +55,7 @@ const AsyncStorage = {
   },
 
   multiGet(keys, callback) {
-    return wrap(keys.map(k => [k, db[k]]), callback);
+    return wrap(keys.map(k => [k, db[k] || null]), callback);
   },
 
   multiSet(keyValuePairs, callback) {


### PR DESCRIPTION
Currently I getting `undefined` for `AsyncStorage.getItem` if no items for key, but it's expect `null` for React Native, If I use `JSON.parse` there will be different results:

``` js
// Uncaught SyntaxError: Unexpected token u in JSON at position 0
JSON.parse(undefined)
// null
JSON.parse(null)
```
