### PR TITLE
Add NavigationCard constants

### DIFF
--- a/src/Libraries/NavigationExperimental/NavigationCard.js
+++ b/src/Libraries/NavigationExperimental/NavigationCard.js
@@ -1,19 +1,21 @@
+import React from 'react';
+
 class CardStackPanResponder {
 }
 
 class PagerPanResponder {
 }
 
-const NavigationCard = (props) => null;
-
-NavigationCard.CardStackPanResponder = CardStackPanResponder;
-NavigationCard.CardStackStyleInterpolator = {
-  forHorizontal: () => ({}),
-  forVertical: () => ({}),
-};
-NavigationCard.PagerPanResponder = PagerPanResponder;
-NavigationCard.PagerStyleInterpolator = {
-  forHorizontal: () => ({}),
-};
+class NavigationCard extends React.Component {
+  static CardStackPanResponder = CardStackPanResponder;
+  static CardStackStyleInterpolator = {
+    forHorizontal: () => ({}),
+    forVertical: () => ({}),
+  };
+  static PagerPanResponder = PagerPanResponder;
+  static PagerStyleInterpolator = {
+    forHorizontal: () => ({}),
+  };
+}
 
 module.exports = NavigationCard;

--- a/src/Libraries/NavigationExperimental/NavigationCard.js
+++ b/src/Libraries/NavigationExperimental/NavigationCard.js
@@ -1,4 +1,4 @@
-import createMockComponent from '../../components/createMockComponent';
+import React from 'react';
 
 class CardStackPanResponder {
 }
@@ -6,7 +6,8 @@ class CardStackPanResponder {
 class PagerPanResponder {
 }
 
-const NavigationCard = createMockComponent('NavigationCard');
+class NavigationCard extends React.Component {
+}
 
 NavigationCard.CardStackPanResponder = CardStackPanResponder;
 NavigationCard.CardStackStyleInterpolator = {

--- a/src/Libraries/NavigationExperimental/NavigationCard.js
+++ b/src/Libraries/NavigationExperimental/NavigationCard.js
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import createMockComponent from '../../components/createMockComponent';
 
 class CardStackPanResponder {

--- a/src/Libraries/NavigationExperimental/NavigationCard.js
+++ b/src/Libraries/NavigationExperimental/NavigationCard.js
@@ -1,13 +1,10 @@
-import React from 'react';
-
 class CardStackPanResponder {
 }
 
 class PagerPanResponder {
 }
 
-class NavigationCard extends React.Component {
-}
+const NavigationCard = (props) => null;
 
 NavigationCard.CardStackPanResponder = CardStackPanResponder;
 NavigationCard.CardStackStyleInterpolator = {

--- a/src/Libraries/NavigationExperimental/NavigationCard.js
+++ b/src/Libraries/NavigationExperimental/NavigationCard.js
@@ -1,0 +1,23 @@
+import React from 'react';
+
+import createMockComponent from '../../components/createMockComponent';
+
+class CardStackPanResponder {
+}
+
+class PagerPanResponder {
+}
+
+const NavigationCard = createMockComponent('NavigationCard');
+
+NavigationCard.CardStackPanResponder = CardStackPanResponder;
+NavigationCard.CardStackStyleInterpolator = {
+  forHorizontal: () => ({}),
+  forVertical: () => ({}),
+};
+NavigationCard.PagerPanResponder = PagerPanResponder;
+NavigationCard.PagerStyleInterpolator = {
+  forHorizontal: () => ({}),
+};
+
+module.exports = NavigationCard;

--- a/src/Libraries/NavigationExperimental/index.js
+++ b/src/Libraries/NavigationExperimental/index.js
@@ -3,6 +3,7 @@
  */
 import createMockComponent from '../../components/createMockComponent';
 import StateUtils from './NavigationStateUtils';
+import Card from './NavigationCard';
 import PropTypes from './NavigationPropTypes';
 
 module.exports = {
@@ -11,7 +12,7 @@ module.exports = {
   AnimatedView: createMockComponent('NavigationAnimatedView'),
   Transitioner: createMockComponent('NavigationTransitioner'),
 
-  Card: createMockComponent('NavigationCard'),
+  Card,
   CardStack: createMockComponent('NavigationCardStack'),
   Header: createMockComponent('NavigationHeader'),
 


### PR DESCRIPTION
Currently any use with [react-router-native](https://github.com/jmurzy/react-router-native) fails because it expects several classes/functions to be defined on `NavigationExperimental.Card` (see in react-native [here](https://github.com/facebook/react-native/blob/master/Libraries/CustomComponents/NavigationExperimental/NavigationCard.js#L127-L130)).

It also expects `forHorizontal` and `forVertical` in `CardStackStyleInterpolator` and `forHorizontal` in `PagerStyleInterpolator`, all on load.

This PR adds all those mocks to the existing NavigationExperimental mock.

Thanks for the hard work put into this library!
