### PR TITLE
Add remaining keyboard methods

### DIFF
--- a/src/api/Keyboard.js
+++ b/src/api/Keyboard.js
@@ -3,7 +3,10 @@ const Keyboard = {
     return {
       remove: () => {}
     };
-  }
+  },
+  removeListener: () => {},
+  removeAllListeners: () => {},
+  dismiss: () => {}
 };
 
 module.exports = Keyboard;


### PR DESCRIPTION
- [x] Adds the remaining react-native Keyboard events to bring it in line with release 0.36