### PR TITLE
Add newly added Button component

### DIFF
--- a/src/react-native.js
+++ b/src/react-native.js
@@ -11,6 +11,7 @@ const ReactNative = {
   ActivityIndicator: require('./components/ActivityIndicator'),
   ActivityIndicatorIOS: require('./components/ActivityIndicatorIOS'),
   ART: require('./components/ART'),
+  Button: createMockComponent('Button'),
   DatePickerIOS: createMockComponent('DatePickerIOS'),
   DrawerLayoutAndroid: require('./components/DrawerLayoutAndroid'),
   Image: require('./components/Image'),


### PR DESCRIPTION
This PR addes the support for the newly added [Button](https://facebook.github.io/react-native/docs/button.html) component.