### PR TITLE
Remove deprecated babel dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
   },
   "homepage": "https://github.com/RealOrangeOne/react-native-mock#readme",
   "devDependencies": {
-    "babel": "6.5.2",
     "babel-cli": "6.9.0",
     "babel-core": "6.9.0",
     "babel-eslint": "6.0.4",


### PR DESCRIPTION
`babel` has been deprecated in favour of `babel-cli`, which is also included. This has thrown a few warnings and should probably be removed.