### PR TITLE
Add Network mocks: XMLHttpRequest, FormData, Headers, Response

### DIFF
--- a/src/Libraries/Network/FormData.js
+++ b/src/Libraries/Network/FormData.js
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule FormData
+ * @flow
+ */
+
+type FormDataValue = any;
+type FormDataNameValuePair = [string, FormDataValue];
+
+type Headers = {[name: string]: string};
+type FormDataPart = {
+  string: string,
+  headers: Headers,
+} | {
+  uri: string,
+  headers: Headers,
+  name?: string,
+  type?: string,
+};
+
+/**
+ * Polyfill for XMLHttpRequest2 FormData API, allowing multipart POST requests
+ * with mixed data (string, native files) to be submitted via XMLHttpRequest.
+ *
+ * Example:
+ *
+ *   var photo = {
+ *     uri: uriFromCameraRoll,
+ *     type: 'image/jpeg',
+ *     name: 'photo.jpg',
+ *   };
+ *
+ *   var body = new FormData();
+ *   body.append('authToken', 'secret');
+ *   body.append('photo', photo);
+ *   body.append('title', 'A beautiful photo!');
+ *
+ *   xhr.open('POST', serverURL);
+ *   xhr.send(body);
+ */
+class FormData {
+  _parts: Array<FormDataNameValuePair>;
+
+  constructor() {
+    this._parts = [];
+  }
+
+  append(key: string, value: FormDataValue) {
+    // The XMLHttpRequest spec doesn't specify if duplicate keys are allowed.
+    // MDN says that any new values should be appended to existing values.
+    // In any case, major browsers allow duplicate keys, so that's what we'll do
+    // too. They'll simply get appended as additional form data parts in the
+    // request body, leaving the server to deal with them.
+    this._parts.push([key, value]);
+  }
+
+  getParts(): Array<FormDataPart> {
+    return this._parts.map(([name, value]) => {
+      const contentDisposition = 'form-data; name="' + name + '"';
+
+      const headers: Headers = { 'content-disposition': contentDisposition };
+
+      // The body part is a "blob", which in React Native just means
+      // an object with a `uri` attribute. Optionally, it can also
+      // have a `name` and `type` attribute to specify filename and
+      // content type (cf. web Blob interface.)
+      if (typeof value === 'object') {
+        if (typeof value.name === 'string') {
+          headers['content-disposition'] += '; filename="' + value.name + '"';
+        }
+        if (typeof value.type === 'string') {
+          headers['content-type'] = value.type;
+        }
+        return { ...value, headers, fieldName: name };
+      }
+      // Convert non-object values to strings as per FormData.append() spec
+      return { string: String(value), headers, fieldName: name };
+    });
+  }
+}
+
+module.exports = FormData;

--- a/src/Libraries/Network/Headers.js
+++ b/src/Libraries/Network/Headers.js
@@ -1,0 +1,54 @@
+class Headers {
+  _headers: Object;
+
+  constructor() {
+    this._headers = [];
+  }
+
+  append(name: string, value: string) {
+    const normalName: string = name.toLowerCase();
+    this._headers.push({ name: normalName, value });
+  }
+
+  delete(name: string) {
+    const normalName: string = name.toLowerCase();
+    this._headers = this._headers.filter((pair) => pair.name !== normalName);
+  }
+
+  entries() {
+    return this._headers.entries();
+  }
+
+  get(name: string) {
+    const normalName: string = name.toLowerCase();
+    const header = this._headers.find((pair) => pair.name === normalName);
+    return header ? header.value : undefined;
+  }
+
+  getAll(name: string) {
+    const normalName: string = name.toLowerCase();
+    const headers = this._headers.filter((pair) => pair.name === normalName);
+    return headers.map((pair) => pair.value);
+  }
+
+  has(name: string) {
+    const normalName: string = name.toLowerCase();
+    return this.get(normalName);
+  }
+
+  keys() {
+    return this._headers.map((pair) => pair.name);
+  }
+
+  set(name: string, value: string) {
+    const normalName: string = name.toLowerCase();
+    this.delete(normalName);
+    this.append(normalName, value);
+  }
+
+  values() {
+    return this._headers.map((pair) => pair.value);
+  }
+}
+
+module.exports = Headers;

--- a/src/Libraries/Network/Response.js
+++ b/src/Libraries/Network/Response.js
@@ -1,0 +1,25 @@
+class Response {
+  _status: number;
+  _headers: Headers;
+  _body: string;
+
+  constructor() {
+    this._status = 200;
+    this._headers = new Headers();
+    this._body = '';
+  }
+
+  get status(): number {
+    return this._status;
+  }
+
+  get headers(): Headers {
+    return this._headers;
+  }
+
+  get body(): string {
+    return this._body;
+  }
+}
+
+module.exports = Response;

--- a/src/Libraries/Network/XMLHttpRequest.js
+++ b/src/Libraries/Network/XMLHttpRequest.js
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule XMLHttpRequest
+ * @flow
+ */
+
+const UNSENT = 0;
+const OPENED = 1;
+const HEADERS_RECEIVED = 2;
+const LOADING = 3;
+const DONE = 4;
+
+class XMLHttpRequest {
+  static UNSENT: number = UNSENT;
+  static OPENED: number = OPENED;
+  static HEADERS_RECEIVED: number = HEADERS_RECEIVED;
+  static LOADING: number = LOADING;
+  static DONE: number = DONE;
+
+  UNSENT: number = UNSENT;
+  OPENED: number = OPENED;
+  HEADERS_RECEIVED: number = HEADERS_RECEIVED;
+  LOADING: number = LOADING;
+  DONE: number = DONE;
+
+  onload: ?Function;
+  onloadstart: ?Function;
+  onprogress: ?Function;
+  ontimeout: ?Function;
+  onerror: ?Function;
+  onloadend: ?Function;
+  onreadystatechange: ?Function;
+
+  readyState: number = UNSENT;
+  responseHeaders: ?Object;
+  status: number = 0;
+  timeout: number = 0;
+  responseURL: ?string;
+
+  upload: {
+    addEventListener: ?Function;
+  };
+
+  open(method: string, url: string, async: ?boolean): void {
+  }
+
+  send(data: any): void {
+  }
+
+  abort(): void {
+  }
+}
+
+module.exports = XMLHttpRequest;

--- a/src/defineGlobalProperty.js
+++ b/src/defineGlobalProperty.js
@@ -1,0 +1,8 @@
+function defineGlobalProperty(name, value) {
+  Object.defineProperty(global, name, {
+    configurable: true,
+    value: value(),
+  });
+}
+
+export default defineGlobalProperty;

--- a/src/react-native.js
+++ b/src/react-native.js
@@ -4,6 +4,7 @@
 import React from 'react';
 
 import createMockComponent from './components/createMockComponent';
+import defineGlobalProperty from './defineGlobalProperty';
 
 // Export React, plus some native additions.
 const ReactNative = {
@@ -120,5 +121,11 @@ const ReactNativeAddons = {
 };
 
 Object.assign(ReactNative, React, { addons: ReactNativeAddons });
+
+// Global properties defined in https://github.com/facebook/react-native/blob/master/Libraries/Core/InitializeCore.js
+defineGlobalProperty('XMLHttpRequest', () => require('./Libraries/Network/XMLHttpRequest'));
+defineGlobalProperty('FormData', () => require('./Libraries/Network/FormData'));
+defineGlobalProperty('Headers', () => require('./Libraries/Network/Headers'));
+defineGlobalProperty('Response', () => require('./Libraries/Network/Response'));
 
 module.exports = ReactNative;


### PR DESCRIPTION
I have some tests that rely on network APIs that exist in React Native but not in react-native-mock. This PR adds those APIs and resolves https://github.com/RealOrangeOne/react-native-mock/issues/103.

* `FormData`
* `Headers`
* `Response`
* `XMLHttpRequest`