### PR TITLE
Fixes issue with TabBarIOS.  Adds Picker.Item

### DIFF
--- a/src/components/Picker.js
+++ b/src/components/Picker.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import createMockComponent from './createMockComponent';
+
+const Picker = React.createClass({
+  propTypes: {
+    children: React.PropTypes.node
+  },
+  statics: {
+    Item: createMockComponent('Picker.Item')
+  },
+  render() {
+    return null;
+  }
+});
+
+module.exports = Picker;

--- a/src/components/TabBarIOS.js
+++ b/src/components/TabBarIOS.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import createMockComponent from './createMockComponent';
+
+const TabBarIOS = React.createClass({
+  propTypes: {
+    children: React.PropTypes.node
+  },
+  statics: {
+    Item: createMockComponent('TabBarIOS.Item')
+  },
+  render() {
+    return null;
+  }
+});
+
+module.exports = TabBarIOS;

--- a/src/react-native.js
+++ b/src/react-native.js
@@ -24,7 +24,7 @@ const ReactNative = {
   Modal: createMockComponent('Modal'),
   Navigator: require('./components/Navigator'),
   NavigatorIOS: createMockComponent('NavigatorIOS'),
-  Picker: createMockComponent('Picker'),
+  Picker: require('./components/Picker'),
   PickerIOS: createMockComponent('PickerIOS'),
   ProgressBarAndroid: createMockComponent('ProgressBarAndroid'),
   ProgressViewIOS: createMockComponent('ProgressViewIOS'),
@@ -39,10 +39,7 @@ const ReactNative = {
   StatusBar: require('./components/StatusBar'),
   SwitchAndroid: createMockComponent('SwitchAndroid'),
   SwitchIOS: createMockComponent('SwitchIOS'),
-  TabBarIOS: {
-    ...createMockComponent('TabBarIOS'),
-    Item: createMockComponent('TabBarIOS.Item')
-  },
+  TabBarIOS: require('./components/TabBarIOS'),
   Text: require('./components/Text'),
   TextInput: require('./components/TextInput'),
   ToastAndroid: createMockComponent('ToastAndroid'),

--- a/test/components/Picker.js
+++ b/test/components/Picker.js
@@ -1,0 +1,12 @@
+import { expect } from 'chai';
+import Picker from '../../src/components/Picker.js';
+
+describe('Picker', () => {
+  it('is renderable', () => {
+    expect(Picker).to.be.a('function');
+  });
+
+  it('.Item is renderable', () => {
+    expect(Picker.Item).to.be.a('function');
+  });
+});

--- a/test/components/TabBarIOS.js
+++ b/test/components/TabBarIOS.js
@@ -1,0 +1,12 @@
+import { expect } from 'chai';
+import TabBarIOS from '../../src/components/TabBarIOS.js';
+
+describe('TabBarIOS', () => {
+  it('is renderable', () => {
+    expect(TabBarIOS).to.be.a('function');
+  });
+
+  it('.Item is renderable', () => {
+    expect(TabBarIOS.Item).to.be.a('function');
+  });
+});


### PR DESCRIPTION
I ran into an issue where the current implementation of `TabBarIOS` would not render properly.  Using the component would produce errors like this one: 
> Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: object.  Check the render method of \<my-component>

This fixes that and implements the same structure for `Picker`.  `Picker.Item` is also renderable in react-native and this was not previously implemented in react-native-mock.