### PR TITLE
Make react-dom a peer dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,12 +54,12 @@
     "react-addons-pure-render-mixin": "^15.4.0",
     "react-addons-test-utils": "^15.4.0",
     "react-addons-update": "^15.4.0",
-    "react-dom": "^15.4.0",
     "react-timer-mixin": "^0.13.3",
     "warning": "^2.1.0"
   },
   "peerDependencies": {
     "react": "*",
-    "react-native": "*"
+    "react-native": "*",
+    "react-dom": "^15.4.0"
   }
 }


### PR DESCRIPTION
My setup is a bit unusual, but I ran into trouble due to two copies of react-dom. All three of them should be peer dependences, since react-native-mock shouldn't really use it's own copy.