### PR TITLE
Imported PropTypes from prop-types everywhere

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "cubic-bezier": "^0.1.2",
     "invariant": "^2.2.1",
     "keymirror": "^0.1.1",
+    "prop-types": "^15.6.0",
     "raf": "^3.2.0",
     "react-addons-create-fragment": "^15.4.0",
     "react-addons-perf": "^15.4.0",

--- a/package.json
+++ b/package.json
@@ -41,8 +41,8 @@
     "eslint-plugin-react": "5.1.1",
     "eslint-plugin-react-native": "1.0.2",
     "mocha": "2.5.3",
-    "react": "^15.4.0",
-    "react-native": "^0.38.0"
+    "react": "~15.4.1",
+    "react-native": "^0.42.0"
   },
   "dependencies": {
     "cubic-bezier": "^0.1.2",
@@ -55,7 +55,7 @@
     "react-addons-pure-render-mixin": "^15.4.0",
     "react-addons-test-utils": "^15.4.0",
     "react-addons-update": "^15.4.0",
-    "react-dom": "^15.4.0",
+    "react-dom": "~15.4.1",
     "react-timer-mixin": "^0.13.3",
     "warning": "^2.1.0"
   },

--- a/src/Libraries/NavigationExperimental/NavigationPropTypes.js
+++ b/src/Libraries/NavigationExperimental/NavigationPropTypes.js
@@ -1,8 +1,6 @@
 class Animated {}
 
-import React from 'react';
-
-const { PropTypes } = React;
+import PropTypes from 'prop-types';
 
 /* NavigationAction */
 const action = PropTypes.shape({

--- a/src/api/CameraRoll.js
+++ b/src/api/CameraRoll.js
@@ -1,8 +1,7 @@
 import invariant from 'invariant';
-import React from 'react';
 import CameraRollManager from '../NativeModules/CameraRollManager';
 
-const { PropTypes } = React;
+import PropTypes from 'prop-types';
 
 const GROUP_TYPES_OPTIONS = [
   'Album',

--- a/src/api/LayoutAnimation.js
+++ b/src/api/LayoutAnimation.js
@@ -1,8 +1,7 @@
-import React from 'react';
 import UIManager from '../NativeModules/UIManager';
 import keyMirror from 'keymirror';
 
-const { PropTypes } = React;
+import PropTypes from 'prop-types';
 
 const TypesEnum = {
   spring: true,

--- a/src/components/ActivityIndicator.js
+++ b/src/components/ActivityIndicator.js
@@ -6,7 +6,7 @@ import NativeMethodsMixin from '../mixins/NativeMethodsMixin';
 import View from './View';
 import ColorPropType from '../propTypes/ColorPropType';
 
-const { PropTypes } = React;
+import PropTypes from 'prop-types';
 
 const ActivityIndicator = React.createClass({
   propTypes: {

--- a/src/components/ActivityIndicatorIOS.js
+++ b/src/components/ActivityIndicatorIOS.js
@@ -5,7 +5,7 @@ import React from 'react';
 import NativeMethodsMixin from '../mixins/NativeMethodsMixin';
 import View from './View';
 
-const { PropTypes } = React;
+import PropTypes from 'prop-types';
 
 const ActivityIndicatorIOS = React.createClass({
   propTypes: {

--- a/src/components/Image.js
+++ b/src/components/Image.js
@@ -8,7 +8,7 @@ import EdgeInsetsPropType from '../propTypes/EdgeInsetsPropType';
 import ImageStylePropTypes from '../propTypes/ImageStylePropTypes';
 import ImageResizeMode from '../propTypes/ImageResizeMode';
 
-const { PropTypes } = React;
+import PropTypes from 'prop-types';
 
 const Image = React.createClass({
   propTypes: {

--- a/src/components/ListView.js
+++ b/src/components/ListView.js
@@ -4,7 +4,7 @@ import TimerMixin from 'react-timer-mixin';
 import ScrollView from './ScrollView';
 import ListViewDataSource from '../api/ListViewDataSource';
 
-const { PropTypes } = React;
+import PropTypes from 'prop-types';
 const SCROLLVIEW_REF = 'listviewscroll';
 
 

--- a/src/components/ScrollView.js
+++ b/src/components/ScrollView.js
@@ -7,7 +7,7 @@ import ViewStylePropTypes from '../propTypes/ViewStylePropTypes';
 import ScrollViewManager from '../NativeModules/ScrollViewManager';
 import styleSheetPropType from '../propTypes/StyleSheetPropType';
 
-const { PropTypes } = React;
+import PropTypes from 'prop-types';
 
 const SCROLLVIEW = 'ScrollView';
 const INNERVIEW = 'InnerScrollView';

--- a/src/components/TextInput.js
+++ b/src/components/TextInput.js
@@ -5,7 +5,7 @@ import NativeMethodsMixin from '../mixins/NativeMethodsMixin';
 import View from './View';
 import Text from './Text';
 
-const { PropTypes } = React;
+import PropTypes from 'prop-types';
 
 const TextInput = React.createClass({
   propTypes: {

--- a/src/components/WebView.js
+++ b/src/components/WebView.js
@@ -4,7 +4,7 @@ import View from './View';
 import ScrollView from './ScrollView';
 import WebViewManager from '../NativeModules/WebViewManager';
 
-const { PropTypes } = React;
+import PropTypes from 'prop-types';
 
 const RCT_WEBVIEW_REF = 'webview';
 

--- a/src/propTypes/EdgeInsetsPropType.js
+++ b/src/propTypes/EdgeInsetsPropType.js
@@ -1,9 +1,7 @@
 /**
  * https://github.com/facebook/react-native/blob/master/Libraries/StyleSheet/EdgeInsetsPropType.js
  */
-import React from 'react';
-
-const { PropTypes } = React;
+import PropTypes from 'prop-types';
 
 const EdgeInsetsPropType = PropTypes.shape({
   top: PropTypes.number,

--- a/src/propTypes/ImageStylePropTypes.js
+++ b/src/propTypes/ImageStylePropTypes.js
@@ -1,14 +1,13 @@
 /**
  * https://github.com/facebook/react-native/blob/master/Libraries/Image/ImageStylePropTypes.js
  */
-import React from 'react';
 import ColorPropType from './ColorPropType';
 import TransformPropTypes from './TransformPropTypes';
 import ShadowPropTypesIOS from './ShadowPropTypesIOS';
 import LayoutPropTypes from './LayoutPropTypes';
 import ImageResizeMode from './ImageResizeMode';
 
-const { PropTypes } = React;
+import PropTypes from 'prop-types';
 
 const ImageStylePropTypes = {
   ...LayoutPropTypes,

--- a/src/propTypes/LayoutPropTypes.js
+++ b/src/propTypes/LayoutPropTypes.js
@@ -1,9 +1,7 @@
 /**
  * https://github.com/facebook/react-native/blob/master/Libraries/StyleSheet/LayoutPropTypes.js
  */
-import React from 'react';
-
-const { PropTypes } = React;
+import PropTypes from 'prop-types';
 
 /**
  * React Native's layout system is based on Flexbox and is powered both

--- a/src/propTypes/PointPropType.js
+++ b/src/propTypes/PointPropType.js
@@ -1,9 +1,7 @@
 /**
  * https://github.com/facebook/react-native/blob/master/Libraries/StyleSheet/PointPropType.js
  */
-import React from 'react';
-
-const { PropTypes } = React;
+import PropTypes from 'prop-types';
 
 const PointPropType = PropTypes.shape({
   x: PropTypes.number,

--- a/src/propTypes/ShadowPropTypesIOS.js
+++ b/src/propTypes/ShadowPropTypesIOS.js
@@ -1,7 +1,6 @@
-import React from 'react';
 import ColorPropType from './ColorPropType';
 
-const { PropTypes } = React;
+import PropTypes from 'prop-types';
 
 const ShadowPropTypesIOS = {
   /**

--- a/src/propTypes/StyleSheetPropType.js
+++ b/src/propTypes/StyleSheetPropType.js
@@ -1,10 +1,9 @@
 /**
  * https://github.com/facebook/react-native/blob/master/Libraries/StyleSheet/StyleSheetPropType.js
  */
-import React from 'react';
 import flattenStyle from './flattenStyle';
 
-const { PropTypes } = React;
+import PropTypes from 'prop-types';
 
 function StyleSheetPropType(shape) {
   const shapePropType = PropTypes.shape(shape);

--- a/src/propTypes/TextStylePropTypes.js
+++ b/src/propTypes/TextStylePropTypes.js
@@ -1,11 +1,10 @@
 /**
  * https://github.com/facebook/react-native/blob/master/Libraries/Text/TextStylePropTypes.js
  */
-import React from 'react';
 import ColorPropType from './ColorPropType';
 import ViewStylePropTypes from './ViewStylePropTypes';
 
-const { PropTypes } = React;
+import PropTypes from 'prop-types';
 
 // TODO: use spread instead of Object.assign/create after #6560135 is fixed
 const TextStylePropTypes = Object.assign(Object.create(ViewStylePropTypes), {

--- a/src/propTypes/TransformPropTypes.js
+++ b/src/propTypes/TransformPropTypes.js
@@ -1,9 +1,7 @@
 /**
  * https://github.com/facebook/react-native/blob/master/Libraries/StyleSheet/TransformPropTypes.js
  */
-import React from 'react';
-
-const { PropTypes } = React;
+import PropTypes from 'prop-types';
 
 const arrayOfNumberPropType = PropTypes.arrayOf(PropTypes.number);
 

--- a/src/propTypes/ViewPropTypes.js
+++ b/src/propTypes/ViewPropTypes.js
@@ -2,7 +2,6 @@
  * https://github.com/facebook/react-native/blob/master/Libraries/Components/View/ViewPropTypes.js
  */
 
-import React from 'react';
 import EdgeInsetsPropType from './EdgeInsetsPropType';
 import styleSheetPropType from './StyleSheetPropType';
 import ViewStylePropTypes from './ViewStylePropTypes';
@@ -10,7 +9,7 @@ import { AccessibilityComponentTypes, AccessibilityTraits } from '../components/
 
 const stylePropType = styleSheetPropType(ViewStylePropTypes);
 
-const { PropTypes } = React;
+import PropTypes from 'prop-types';
 
 const ViewPropTypes = {
   /**

--- a/src/propTypes/ViewStylePropTypes.js
+++ b/src/propTypes/ViewStylePropTypes.js
@@ -1,13 +1,12 @@
 /**
  * https://github.com/facebook/react-native/blob/master/Libraries/Components/View/ViewStylePropTypes.js
  */
-import React from 'react';
 import ColorPropType from './ColorPropType';
 import LayoutPropTypes from './LayoutPropTypes';
 import ShadowPropTypesIOS from './ShadowPropTypesIOS';
 import TransformPropTypes from './TransformPropTypes';
 
-const { PropTypes } = React;
+import PropTypes from 'prop-types';
 
 /**
  * Warning: Some of these properties may not be supported in all releases.


### PR DESCRIPTION
Changed PropTypes imports to use `prop-types` package instead of React's bundled PropTypes. I had experienced this bug https://github.com/RealOrangeOne/react-native-mock/issues/139, then fixed it using the latest master but I got a similar one with `shape` instead of `number`. This fixes that.

**Note:** Modifies version numbers in `package.json` in order to resolve `peerDependencies` properly.