### PR TITLE
Migrate to ES6

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "cubic-bezier": "^0.1.2",
     "invariant": "^2.2.1",
     "keymirror": "^0.1.1",
+    "prop-types": "^15.6.0",
     "raf": "^3.2.0",
     "react-addons-create-fragment": "^15.4.0",
     "react-addons-perf": "^15.4.0",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "eslint-plugin-react-native": "1.0.2",
     "mocha": "2.5.3",
     "react": "~15.4.1",
+    "react-dom": "^15.4.2",
     "react-native": "^0.42.0"
   },
   "dependencies": {
@@ -56,6 +57,7 @@
     "react-addons-test-utils": "^15.4.0",
     "react-addons-update": "^15.4.0",
     "react-dom": "~15.4.1",
+    "react-mixin": "^2.0.2",
     "react-timer-mixin": "^0.13.3",
     "warning": "^2.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -41,8 +41,8 @@
     "eslint-plugin-react": "5.1.1",
     "eslint-plugin-react-native": "1.0.2",
     "mocha": "2.5.3",
-    "react": "^15.4.0",
-    "react-native": "^0.38.0"
+    "react": "~15.4.1",
+    "react-native": "^0.42.0"
   },
   "dependencies": {
     "cubic-bezier": "^0.1.2",
@@ -55,7 +55,7 @@
     "react-addons-pure-render-mixin": "^15.4.0",
     "react-addons-test-utils": "^15.4.0",
     "react-addons-update": "^15.4.0",
-    "react-dom": "^15.4.0",
+    "react-dom": "~15.4.1",
     "react-timer-mixin": "^0.13.3",
     "warning": "^2.1.0"
   },

--- a/src/Libraries/NavigationExperimental/NavigationPropTypes.js
+++ b/src/Libraries/NavigationExperimental/NavigationPropTypes.js
@@ -1,8 +1,6 @@
 class Animated {}
 
-import React from 'react';
-
-const { PropTypes } = React;
+import PropTypes from 'prop-types';
 
 /* NavigationAction */
 const action = PropTypes.shape({

--- a/src/api/CameraRoll.js
+++ b/src/api/CameraRoll.js
@@ -1,8 +1,7 @@
 import invariant from 'invariant';
-import React from 'react';
 import CameraRollManager from '../NativeModules/CameraRollManager';
 
-const { PropTypes } = React;
+import PropTypes from 'prop-types';
 
 const GROUP_TYPES_OPTIONS = [
   'Album',

--- a/src/api/LayoutAnimation.js
+++ b/src/api/LayoutAnimation.js
@@ -1,8 +1,7 @@
-import React from 'react';
 import UIManager from '../NativeModules/UIManager';
 import keyMirror from 'keymirror';
 
-const { PropTypes } = React;
+import PropTypes from 'prop-types';
 
 const TypesEnum = {
   spring: true,

--- a/src/components/ActivityIndicator.js
+++ b/src/components/ActivityIndicator.js
@@ -5,11 +5,11 @@ import React from 'react';
 import NativeMethodsMixin from '../mixins/NativeMethodsMixin';
 import View from './View';
 import ColorPropType from '../propTypes/ColorPropType';
-
 import PropTypes from 'prop-types';
+import reactMixin from 'react-mixin';
 
-const ActivityIndicator = React.createClass({
-  propTypes: {
+class ActivityIndicator extends React.Component {
+  static propTypes = {
     ...View.propTypes,
     /**
      * Whether to show the indicator (true, the default) or hide it (false).
@@ -36,11 +36,12 @@ const ActivityIndicator = React.createClass({
      *   {nativeEvent: { layout: {x, y, width, height}}}.
      */
     onLayout: PropTypes.func,
-  },
-  mixins: [NativeMethodsMixin],
+  };
   render() {
     return null;
-  },
-});
+  }
+}
+
+reactMixin(ActivityIndicator.prototype, NativeMethodsMixin);
 
 module.exports = ActivityIndicator;

--- a/src/components/ActivityIndicator.js
+++ b/src/components/ActivityIndicator.js
@@ -6,7 +6,7 @@ import NativeMethodsMixin from '../mixins/NativeMethodsMixin';
 import View from './View';
 import ColorPropType from '../propTypes/ColorPropType';
 
-const { PropTypes } = React;
+import PropTypes from 'prop-types';
 
 const ActivityIndicator = React.createClass({
   propTypes: {

--- a/src/components/ActivityIndicatorIOS.js
+++ b/src/components/ActivityIndicatorIOS.js
@@ -4,11 +4,11 @@
 import React from 'react';
 import NativeMethodsMixin from '../mixins/NativeMethodsMixin';
 import View from './View';
-
 import PropTypes from 'prop-types';
+import reactMixin from 'react-mixin';
 
-const ActivityIndicatorIOS = React.createClass({
-  propTypes: {
+class ActivityIndicatorIOS extends React.Component {
+  static propTypes = {
     ...View.propTypes,
     /**
      * Whether to show the indicator (true, the default) or hide it (false).
@@ -35,13 +35,12 @@ const ActivityIndicatorIOS = React.createClass({
      *   {nativeEvent: { layout: {x, y, width, height}}}.
      */
     onLayout: PropTypes.func,
-  },
-
-  mixins: [NativeMethodsMixin],
-
+  };
   render() {
     return null;
-  },
-});
+  }
+}
+
+reactMixin(ActivityIndicatorIOS.prototype, NativeMethodsMixin);
 
 module.exports = ActivityIndicatorIOS;

--- a/src/components/ActivityIndicatorIOS.js
+++ b/src/components/ActivityIndicatorIOS.js
@@ -5,7 +5,7 @@ import React from 'react';
 import NativeMethodsMixin from '../mixins/NativeMethodsMixin';
 import View from './View';
 
-const { PropTypes } = React;
+import PropTypes from 'prop-types';
 
 const ActivityIndicatorIOS = React.createClass({
   propTypes: {

--- a/src/components/DrawerLayoutAndroid.js
+++ b/src/components/DrawerLayoutAndroid.js
@@ -6,13 +6,14 @@ import NativeMethodsMixin from '../mixins/NativeMethodsMixin';
 import View from './View';
 import UIManager from '../NativeModules/UIManager';
 import ColorPropType from '../propTypes/ColorPropType';
+import ReactPropTypes from 'prop-types';
+import reactMixin from 'react-mixin';
 
-const ReactPropTypes = React.PropTypes;
 const DrawerConsts = UIManager.AndroidDrawerLayout.Constants;
 
-const DrawerLayoutAndroid = React.createClass({
+class DrawerLayoutAndroid extends React.Component {
 
-  propTypes: {
+  static propTypes = {
     ...View.propTypes,
     /**
      * Determines whether the keyboard gets dismissed in response to a drag.
@@ -90,26 +91,23 @@ const DrawerLayoutAndroid = React.createClass({
      * effect on API 21+.
      */
     statusBarBackgroundColor: ColorPropType,
-  },
+  };
 
-  mixins: [NativeMethodsMixin],
-
-  statics: {
-    positions: DrawerConsts.DrawerPosition
-  },
+  static positions = DrawerConsts.DrawerPosition;
 
   openDrawer() {
     // do nothing
-  },
+  }
 
   closeDrawer() {
     // do nothing
-  },
+  }
 
   render() {
     return null;
   }
+}
 
-});
+reactMixin(DrawerLayoutAndroid.prototype, NativeMethodsMixin);
 
 module.exports = DrawerLayoutAndroid;

--- a/src/components/Image.js
+++ b/src/components/Image.js
@@ -7,11 +7,11 @@ import NativeMethodsMixin from '../mixins/NativeMethodsMixin';
 import EdgeInsetsPropType from '../propTypes/EdgeInsetsPropType';
 import ImageStylePropTypes from '../propTypes/ImageStylePropTypes';
 import ImageResizeMode from '../propTypes/ImageResizeMode';
-
 import PropTypes from 'prop-types';
+import reactMixin from 'react-mixin';
 
-const Image = React.createClass({
-  propTypes: {
+class Image extends React.Component {
+  static propTypes = {
     style: styleSheetPropType(ImageStylePropTypes),
     /**
      * `uri` is a string representing the resource identifier for the image, which
@@ -108,20 +108,15 @@ const Image = React.createClass({
      * Invoked when load either succeeds or fails
      */
     onLoadEnd: PropTypes.func,
-  },
-  mixins: [NativeMethodsMixin],
-  statics: {
-    resizeMode: ImageResizeMode,
-    getSize(uri, success, failure) {
-
-    },
-    prefetch(uri) {
-
-    }
-  },
+  };
+  static resizeMode = ImageResizeMode;
+  static getSize(uri, success, failure) {}
+  static prefetch(uri) {}
   render() {
     return null;
-  },
-});
+  }
+}
+
+reactMixin(Image.prototype, NativeMethodsMixin);
 
 module.exports = Image;

--- a/src/components/Image.js
+++ b/src/components/Image.js
@@ -8,7 +8,7 @@ import EdgeInsetsPropType from '../propTypes/EdgeInsetsPropType';
 import ImageStylePropTypes from '../propTypes/ImageStylePropTypes';
 import ImageResizeMode from '../propTypes/ImageResizeMode';
 
-const { PropTypes } = React;
+import PropTypes from 'prop-types';
 
 const Image = React.createClass({
   propTypes: {

--- a/src/components/ListView.js
+++ b/src/components/ListView.js
@@ -3,13 +3,13 @@ import ScrollResponder from '../mixins/ScrollResponder';
 import TimerMixin from 'react-timer-mixin';
 import ScrollView from './ScrollView';
 import ListViewDataSource from '../api/ListViewDataSource';
-
 import PropTypes from 'prop-types';
+import reactMixin from 'react-mixin';
+
 const SCROLLVIEW_REF = 'listviewscroll';
 
-
-const ListView = React.createClass({
-  propTypes: {
+class ListView extends React.Component {
+  static propTypes = {
     ...ScrollView.propTypes,
 
     dataSource: PropTypes.instanceOf(ListViewDataSource).isRequired,
@@ -80,12 +80,12 @@ const ListView = React.createClass({
      * A function that returns the scrollable component in which the list rows
      * are rendered. Defaults to returning a ScrollView with the given props.
      */
-    renderScrollComponent: React.PropTypes.func.isRequired,
+    renderScrollComponent: PropTypes.func.isRequired,
     /**
      * How early to start rendering rows before they come on screen, in
      * pixels.
      */
-    scrollRenderAheadDistance: React.PropTypes.number,
+    scrollRenderAheadDistance: PropTypes.number,
     /**
      * (visibleRows, changedRows) => void
      *
@@ -95,13 +95,13 @@ const ListView = React.createClass({
      * that have changed their visibility, with true indicating visible, and
      * false indicating the view has moved out of view.
      */
-    onChangeVisibleRows: React.PropTypes.func,
+    onChangeVisibleRows: PropTypes.func,
     /**
      * A performance optimization for improving scroll perf of
      * large lists, used in conjunction with overflow: 'hidden' on the row
      * containers.  This is enabled by default.
      */
-    removeClippedSubviews: React.PropTypes.bool,
+    removeClippedSubviews: PropTypes.bool,
     /**
      * An array of child indices determining which children get docked to the
      * top of the screen when scrolling. For example, passing
@@ -111,12 +111,9 @@ const ListView = React.createClass({
      * @platform ios
      */
     stickyHeaderIndices: PropTypes.arrayOf(PropTypes.number),
-  },
-  mixins: [ScrollResponder.Mixin, TimerMixin],
+  };
 
-  statics: {
-    DataSource: ListViewDataSource,
-  },
+  static DataSource = ListViewDataSource;
 
   /**
    * Exports some data, e.g. for perf investigations or analytics.
@@ -129,11 +126,11 @@ const ListView = React.createClass({
       renderedRows: this.state.curRenderedRowsCount,
       visibleRows: Object.keys(this._visibleRows).length,
     };
-  },
+  }
 
   scrollTo(destY, destX) {
     this.getScrollResponder().scrollResponderScrollTo(destX || 0, destY || 0);
-  },
+  }
 
   /**
    * Provides a handle to the underlying scroll responder to support operations
@@ -143,25 +140,28 @@ const ListView = React.createClass({
     return this.refs[SCROLLVIEW_REF] &&
       this.refs[SCROLLVIEW_REF].getScrollResponder &&
       this.refs[SCROLLVIEW_REF].getScrollResponder();
-  },
+  }
 
   setNativeProps(props) {
     this.refs[SCROLLVIEW_REF].setNativeProps(props);
-  },
+  }
 
   getDefaultProps() {
     return {
       renderScrollComponent: (props) => <ScrollView {...props} />
     };
-  },
+  }
 
   getInnerViewNode() {
     return this.refs[SCROLLVIEW_REF].getInnerViewNode();
-  },
+  }
 
   render() {
     return null;
-  },
-});
+  }
+}
+
+reactMixin(ListView.prototype, ScrollResponder.Mixin);
+reactMixin(ListView.prototype, TimerMixin);
 
 module.exports = ListView;

--- a/src/components/ListView.js
+++ b/src/components/ListView.js
@@ -4,7 +4,7 @@ import TimerMixin from 'react-timer-mixin';
 import ScrollView from './ScrollView';
 import ListViewDataSource from '../api/ListViewDataSource';
 
-const { PropTypes } = React;
+import PropTypes from 'prop-types';
 const SCROLLVIEW_REF = 'listviewscroll';
 
 

--- a/src/components/Navigator.js
+++ b/src/components/Navigator.js
@@ -1,13 +1,14 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
 import createMockComponent from './createMockComponent';
 import View from './View';
+import PropTypes from 'prop-types';
 
 const NavigatorSceneConfigType = PropTypes.shape({
   gestures: PropTypes.object,
   springFriction: PropTypes.number,
   springTension: PropTypes.number,
   defaultTransitionVelocity: PropTypes.number,
-  animationInterpolators: React.PropTypes.object,
+  animationInterpolators: PropTypes.object,
 });
 
 const NavigatorSceneConfigs = {
@@ -23,8 +24,8 @@ const NavigatorSceneConfigs = {
   VerticalDownSwipeJump: NavigatorSceneConfigType
 };
 
-const Navigator = React.createClass({
-  propTypes: {
+class Navigator extends React.Component {
+  static propTypes = {
     /**
      * Optional function that allows configuration about scene animations and
      * gestures. Will be invoked with the route and the routeStack and should
@@ -88,16 +89,15 @@ const Navigator = React.createClass({
      * Styles to apply to the container of each scene
      */
     sceneStyle: View.propTypes.style,
-  },
+  };
 
-  statics: {
-    BreadcrumbNavigationBar: createMockComponent('NavigatorBreadcrumbNavigationBar'),
-    NavigationBar: createMockComponent('NavigatorNavigationBar'),
-    SceneConfigs: NavigatorSceneConfigs,
-  },
+  static BreadcrumbNavigationBar = createMockComponent('NavigatorBreadcrumbNavigationBar');
+  static NavigationBar = createMockComponent('NavigatorNavigationBar');
+  static SceneConfigs = NavigatorSceneConfigs;
+
   render() {
     return null;
   }
-});
+}
 
 module.exports = Navigator;

--- a/src/components/Picker.js
+++ b/src/components/Picker.js
@@ -1,16 +1,15 @@
 import React from 'react';
 import createMockComponent from './createMockComponent';
+import PropTypes from 'prop-types';
 
-const Picker = React.createClass({
-  propTypes: {
-    children: React.PropTypes.node
-  },
-  statics: {
-    Item: createMockComponent('Picker.Item')
-  },
+class Picker extends React.Component {
+  static propTypes = {
+    children: PropTypes.node
+  };
+  static Item = createMockComponent('Picker.Item');
   render() {
     return null;
   }
-});
+}
 
 module.exports = Picker;

--- a/src/components/ScrollView.js
+++ b/src/components/ScrollView.js
@@ -6,14 +6,15 @@ import View from './View';
 import ViewStylePropTypes from '../propTypes/ViewStylePropTypes';
 import ScrollViewManager from '../NativeModules/ScrollViewManager';
 import styleSheetPropType from '../propTypes/StyleSheetPropType';
-
 import PropTypes from 'prop-types';
+import reactMixin from 'react-mixin';
 
 const SCROLLVIEW = 'ScrollView';
 const INNERVIEW = 'InnerScrollView';
 
-const ScrollView = React.createClass({
-  propTypes: {
+
+class ScrollView extends React.Component {
+  static propTypes = {
     ...View.propTypes,
     /**
      * Controls whether iOS should automatically adjust the content inset
@@ -284,13 +285,11 @@ const ScrollView = React.createClass({
      * See [RefreshControl](http://facebook.github.io/react-native/docs/refreshcontrol.html).
      */
     refreshControl: PropTypes.element,
-  },
-
-  mixins: [ScrollResponder.Mixin],
+  };
 
   setNativeProps(props) {
     this.refs[SCROLLVIEW].setNativeProps(props);
-  },
+  }
 
   /**
    * Returns a reference to the underlying scroll responder, which supports
@@ -300,25 +299,27 @@ const ScrollView = React.createClass({
    */
   getScrollResponder() {
     return this;
-  },
+  }
 
   getInnerViewNode() {
     return React.findNodeHandle(this.refs[INNERVIEW]);
-  },
+  }
 
   endRefreshin() {
     ScrollViewManager.endRefreshing(
       React.findNodeHandle(this)
     );
-  },
+  }
 
   scrollTo(destY = 0, destX = 0, animated = true) {
 
-  },
+  }
 
   render() {
     return null;
-  },
-});
+  }
+}
+
+reactMixin(ScrollView.prototype, ScrollResponder.Mixin);
 
 module.exports = ScrollView;

--- a/src/components/ScrollView.js
+++ b/src/components/ScrollView.js
@@ -7,7 +7,7 @@ import ViewStylePropTypes from '../propTypes/ViewStylePropTypes';
 import ScrollViewManager from '../NativeModules/ScrollViewManager';
 import styleSheetPropType from '../propTypes/StyleSheetPropType';
 
-const { PropTypes } = React;
+import PropTypes from 'prop-types';
 
 const SCROLLVIEW = 'ScrollView';
 const INNERVIEW = 'InnerScrollView';

--- a/src/components/StatusBar.js
+++ b/src/components/StatusBar.js
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 import ColorPropType from '../propTypes/ColorPropType';
-
+import PropTypes from 'prop-types';
 
 let _backgroundColor = '';
 let _barStyle = {};
@@ -11,62 +11,60 @@ let _hidden = false;
 let _networkActivityIndicatorVisible = false;
 let _translucent = false;
 
-const StatusBar = React.createClass({
-  propTypes: {
-    animated: React.PropTypes.bool,
-    barStyle: React.PropTypes.oneOf(['default', 'light-content']),
+class StatusBar extends React.Component {
+  static propTypes = {
+    animated: PropTypes.bool,
+    barStyle: PropTypes.oneOf(['default', 'light-content']),
     backgroundColor: ColorPropType,
-    hidden: React.PropTypes.bool,
-    networkActivityIndicatorVisible: React.PropTypes.bool,
-    showHideTransition: React.PropTypes.oneOf(['fade', 'slide']),
-    translucent: React.PropTypes.bool
-  },
+    hidden: PropTypes.bool,
+    networkActivityIndicatorVisible: PropTypes.bool,
+    showHideTransition: PropTypes.oneOf(['fade', 'slide']),
+    translucent: PropTypes.bool
+  };
 
-  statics: {
-    setBackgroundColor(backgroundColor, animated) {
-      _backgroundColor = backgroundColor;
-    },
+  static setBackgroundColor(backgroundColor, animated) {
+    _backgroundColor = backgroundColor;
+  }
 
-    setBarStyle(barStyle, animated) {
-      _barStyle = barStyle;
-    },
+  static setBarStyle(barStyle, animated) {
+    _barStyle = barStyle;
+  }
 
-    setHidden(hidden, animated) {
-      _hidden = hidden;
-    },
+  static setHidden(hidden, animated) {
+    _hidden = hidden;
+  }
 
-    setNetworkActivityIndicatorVisible(visible) {
-      _networkActivityIndicatorVisible = visible;
-    },
+  static setNetworkActivityIndicatorVisible(visible) {
+    _networkActivityIndicatorVisible = visible;
+  }
 
-    setTranslucent(translucent) {
-      _translucent = translucent;
-    },
+  static setTranslucent(translucent) {
+    _translucent = translucent;
+  }
 
-    __getBackgroundColor() {
-      return _backgroundColor;
-    },
+  static __getBackgroundColor() {
+    return _backgroundColor;
+  }
 
-    __getBarStyle() {
-      return _barStyle;
-    },
+  static __getBarStyle() {
+    return _barStyle;
+  }
 
-    __getHidden() {
-      return _hidden;
-    },
+  static __getHidden() {
+    return _hidden;
+  }
 
-    __getNetworkActivityIndicatorVisible() {
-      return _networkActivityIndicatorVisible;
-    },
+  static __getNetworkActivityIndicatorVisible() {
+    return _networkActivityIndicatorVisible;
+  }
 
-    __getTranslucent() {
-      return _translucent;
-    }
-  },
+  static __getTranslucent() {
+    return _translucent;
+  }
 
   render() {
     return null;
   }
-});
+}
 
 module.exports = StatusBar;

--- a/src/components/TabBarIOS.js
+++ b/src/components/TabBarIOS.js
@@ -1,16 +1,15 @@
 import React from 'react';
 import createMockComponent from './createMockComponent';
+import PropTypes from 'prop-types';
 
-const TabBarIOS = React.createClass({
-  propTypes: {
-    children: React.PropTypes.node
-  },
-  statics: {
-    Item: createMockComponent('TabBarIOS.Item')
-  },
+class TabBarIOS extends React.Component {
+  static propTypes = {
+    children: PropTypes.node
+  };
+  static Item = createMockComponent('TabBarIOS.Item');
   render() {
     return null;
   }
-});
+}
 
 module.exports = TabBarIOS;

--- a/src/components/Text.js
+++ b/src/components/Text.js
@@ -5,49 +5,52 @@ import React from 'react';
 import styleSheetPropType from '../propTypes/StyleSheetPropType';
 import TextStylePropTypes from '../propTypes/TextStylePropTypes';
 import NativeMethodsMixin from '../mixins/NativeMethodsMixin';
+import reactMixin from 'react-mixin';
+import PropTypes from 'prop-types';
 
 const stylePropType = styleSheetPropType(TextStylePropTypes);
 
-const Text = React.createClass({
-  propTypes: {
+class Text extends React.Component {
+  static propTypes = {
     /**
      * Used to truncate the text with an ellipsis after computing the text
      * layout, including line wrapping, such that the total number of lines
      * does not exceed this number.
      */
-    numberOfLines: React.PropTypes.number,
+    numberOfLines: PropTypes.number,
     /**
      * Invoked on mount and layout changes with
      *
      *   `{nativeEvent: {layout: {x, y, width, height}}}`
      */
-    onLayout: React.PropTypes.func,
+    onLayout: PropTypes.func,
     /**
      * This function is called on press.
      */
-    onPress: React.PropTypes.func,
+    onPress: PropTypes.func,
     /**
      * When true, no visual change is made when text is pressed down. By
      * default, a gray oval highlights the text on press down.
      * @platform ios
      */
-    suppressHighlighting: React.PropTypes.bool,
+    suppressHighlighting: PropTypes.bool,
     style: stylePropType,
     /**
      * Used to locate this view in end-to-end tests.
      */
-    testID: React.PropTypes.string,
+    testID: PropTypes.string,
     /**
      * Specifies should fonts scale to respect Text Size accessibility setting on iOS.
      * @platform ios
      */
-    allowFontScaling: React.PropTypes.bool,
-  },
-  mixins: [NativeMethodsMixin],
+    allowFontScaling: PropTypes.bool,
+  };
 
   render() {
     return null;
-  },
-});
+  }
+}
+
+reactMixin(Text.prototype, NativeMethodsMixin);
 
 module.exports = Text;

--- a/src/components/TextInput.js
+++ b/src/components/TextInput.js
@@ -4,11 +4,11 @@ import TimerMixin from 'react-timer-mixin';
 import NativeMethodsMixin from '../mixins/NativeMethodsMixin';
 import View from './View';
 import Text from './Text';
-
 import PropTypes from 'prop-types';
+import reactMixin from 'react-mixin';
 
-const TextInput = React.createClass({
-  propTypes: {
+class TextInput extends React.Component {
+  static propTypes = {
     ...View.propTypes,
     /**
      * Can tell TextInput to automatically capitalize certain characters.
@@ -228,22 +228,22 @@ const TextInput = React.createClass({
      * @platform android
      */
     underlineColorAndroid: PropTypes.string,
-  },
-  mixins: [NativeMethodsMixin, TimerMixin],
-  statics: {
-    State: TextInputState,
-  },
+  };
+  static State = TextInputState;
   isFocused() {
     // TODO(lmr): React.findNodeHandle
     return TextInputState.currentlyFocusedField() ===
       React.findNodeHandle(this.refs.input);
-  },
+  }
   clear() {
 
-  },
+  }
   render() {
     return null;
-  },
-});
+  }
+}
+
+reactMixin(TextInput.prototype, NativeMethodsMixin);
+reactMixin(TextInput.prototype, TimerMixin);
 
 module.exports = TextInput;

--- a/src/components/TextInput.js
+++ b/src/components/TextInput.js
@@ -5,7 +5,7 @@ import NativeMethodsMixin from '../mixins/NativeMethodsMixin';
 import View from './View';
 import Text from './Text';
 
-const { PropTypes } = React;
+import PropTypes from 'prop-types';
 
 const TextInput = React.createClass({
   propTypes: {

--- a/src/components/TouchableNativeFeedback.js
+++ b/src/components/TouchableNativeFeedback.js
@@ -1,22 +1,18 @@
-
 import React from 'react';
-
 import TouchableWithoutFeedback from './TouchableWithoutFeedback';
+import PropTypes from 'prop-types';
 
-const TouchableNativeFeedback = React.createClass({
-  propTypes: {
+class TouchableNativeFeedback extends React.Component {
+  static propTypes = {
     ...TouchableWithoutFeedback.propTypes,
-
-    background: React.PropTypes.object
-  },
-  statics: {
-    SelectableBackground() {},
-    SelectableBackgroundBorderless() {},
-    Ripple(color, borderless) {}
-  },
+    background: PropTypes.object
+  };
+  static SelectableBackground() {}
+  static SelectableBackgroundBorderless() {}
+  static Ripple(color, borderless) {}
   render() {
     return null;
   }
-});
+}
 
 module.exports = TouchableNativeFeedback;

--- a/src/components/TouchableOpacity.js
+++ b/src/components/TouchableOpacity.js
@@ -2,23 +2,22 @@
  * https://github.com/facebook/react-native/blob/master/Libraries/Components/Touchable/TouchableOpacity.js
  */
 import React from 'react';
-
 import TouchableWithoutFeedback from './TouchableWithoutFeedback';
+import PropTypes from 'prop-types';
 
-const TouchableOpacity = React.createClass({
-  propTypes: {
+class TouchableOpacity extends React.Component {
+  static propTypes = {
     ...TouchableWithoutFeedback.propTypes,
-
     /**
      * Determines what the opacity of the wrapped view should be when touch is
      * active. Defaults to 0.2.
      */
-    activeOpacity: React.PropTypes.number,
-  },
+    activeOpacity: PropTypes.number,
+  };
 
   render() {
     return null;
-  },
-});
+  }
+}
 
 module.exports = TouchableOpacity;

--- a/src/components/TouchableWithoutFeedback.js
+++ b/src/components/TouchableWithoutFeedback.js
@@ -4,47 +4,48 @@
 import React from 'react';
 import EdgeInsetsPropType from '../propTypes/EdgeInsetsPropType';
 import View from './View';
+import PropTypes from 'prop-types';
 
-const TouchableWithoutFeedback = React.createClass({
-  propTypes: {
-    accessible: React.PropTypes.bool,
-    accessibilityComponentType: React.PropTypes.oneOf(View.AccessibilityComponentType),
-    accessibilityTraits: React.PropTypes.oneOfType([
-      React.PropTypes.oneOf(View.AccessibilityTraits),
-      React.PropTypes.arrayOf(React.PropTypes.oneOf(View.AccessibilityTraits)),
+class TouchableWithoutFeedback extends React.Component {
+  static propTypes = {
+    accessible: PropTypes.bool,
+    accessibilityComponentType: PropTypes.oneOf(View.AccessibilityComponentType),
+    accessibilityTraits: PropTypes.oneOfType([
+      PropTypes.oneOf(View.AccessibilityTraits),
+      PropTypes.arrayOf(PropTypes.oneOf(View.AccessibilityTraits)),
     ]),
     /**
      * If true, disable all interactions for this component.
      */
-    disabled: React.PropTypes.bool,
+    disabled: PropTypes.bool,
     /**
      * Called when the touch is released, but not if cancelled (e.g. by a scroll
      * that steals the responder lock).
      */
-    onPress: React.PropTypes.func,
-    onPressIn: React.PropTypes.func,
-    onPressOut: React.PropTypes.func,
+    onPress: PropTypes.func,
+    onPressIn: PropTypes.func,
+    onPressOut: PropTypes.func,
     /**
      * Invoked on mount and layout changes with
      *
      *   `{nativeEvent: {layout: {x, y, width, height}}}`
      */
-    onLayout: React.PropTypes.func,
+    onLayout: PropTypes.func,
 
-    onLongPress: React.PropTypes.func,
+    onLongPress: PropTypes.func,
 
     /**
      * Delay in ms, from the start of the touch, before onPressIn is called.
      */
-    delayPressIn: React.PropTypes.number,
+    delayPressIn: PropTypes.number,
     /**
      * Delay in ms, from the release of the touch, before onPressOut is called.
      */
-    delayPressOut: React.PropTypes.number,
+    delayPressOut: PropTypes.number,
     /**
      * Delay in ms, from onPressIn, before onLongPress is called.
      */
-    delayLongPress: React.PropTypes.number,
+    delayLongPress: PropTypes.number,
     /**
      * When the scroll view is disabled, this defines how far your touch may
      * move off of the button, before deactivating the button. Once deactivated,
@@ -62,10 +63,10 @@ const TouchableWithoutFeedback = React.createClass({
      * views.
      */
     hitSlop: EdgeInsetsPropType,
-  },
+  };
   render() {
     return null;
-  },
-});
+  }
+}
 
 module.exports = TouchableWithoutFeedback;

--- a/src/components/View.js
+++ b/src/components/View.js
@@ -5,33 +5,26 @@ import React from 'react';
 import ViewAccessibility from './ViewAccessibility';
 import NativeMethodsMixin from '../mixins/NativeMethodsMixin';
 import ViewPropTypes from '../propTypes/ViewPropTypes';
+import reactMixin from 'react-mixin';
 
 const { AccessibilityTraits, AccessibilityComponentTypes } = ViewAccessibility;
 
 const forceTouchAvailable = false;
 
-const statics = {
-  AccessibilityComponentType: AccessibilityComponentTypes,
-  AccessibilityTraits,
+class View extends React.Component {
+  static propTypes = ViewPropTypes;
+  static AccessibilityComponentType: AccessibilityComponentTypes;
+  static AccessibilityTraits = AccessibilityTraits;
   /**
    * Is 3D Touch / Force Touch available (i.e. will touch events include `force`)
    * @platform ios
    */
-  forceTouchAvailable,
-};
-
-const View = React.createClass({
-  propTypes: ViewPropTypes,
-
-  mixins: [NativeMethodsMixin],
-
-  statics: {
-    ...statics,
-  },
-
+  static forceTouchAvailable = forceTouchAvailable;
   render() {
     return null;
-  },
-});
+  }
+}
+
+reactMixin(View.prototype, NativeMethodsMixin);
 
 module.exports = View;

--- a/src/components/WebView.js
+++ b/src/components/WebView.js
@@ -3,7 +3,6 @@ import React from 'react';
 import View from './View';
 import ScrollView from './ScrollView';
 import WebViewManager from '../NativeModules/WebViewManager';
-
 import PropTypes from 'prop-types';
 
 const RCT_WEBVIEW_REF = 'webview';
@@ -19,8 +18,8 @@ const NavigationType = {
 
 const JSNavigationScheme = WebViewManager.JSNavigationScheme;
 
-const WebView = React.createClass({
-  propTypes: {
+class WebView extends React.Component {
+  static propTypes = {
     ...View.propTypes,
     url: PropTypes.string,
     html: PropTypes.string,
@@ -113,33 +112,31 @@ const WebView = React.createClass({
      * @platform ios
      */
     allowsInlineMediaPlayback: PropTypes.bool,
-  },
+  };
 
-  statics: {
-    JSNavigationScheme,
-    NavigationType,
-  },
+  static JSNavigationScheme = JSNavigationScheme;
+  static NavigationType = NavigationType;
 
   getWebViewHandle() {
     // TODO(lmr): React.findNodeHandle
     return React.findNodeHandle(this.refs[RCT_WEBVIEW_REF]);
-  },
+  }
 
   reload() {
     // do nothing
-  },
+  }
 
   goForward() {
     // do nothing
-  },
+  }
 
   goBack() {
     // do nothing
-  },
+  }
 
   render() {
     return null;
-  },
-});
+  }
+}
 
 module.exports = WebView;

--- a/src/components/WebView.js
+++ b/src/components/WebView.js
@@ -4,7 +4,7 @@ import View from './View';
 import ScrollView from './ScrollView';
 import WebViewManager from '../NativeModules/WebViewManager';
 
-const { PropTypes } = React;
+import PropTypes from 'prop-types';
 
 const RCT_WEBVIEW_REF = 'webview';
 

--- a/src/components/createMockComponent.js
+++ b/src/components/createMockComponent.js
@@ -1,12 +1,12 @@
 import React from 'react';
 
 function createMockComponent(displayName) {
-  return React.createClass({
-    displayName,
+  return class extends React.Component {
+    static displayName = displayName;
     render() {
       return null;
-    },
-  });
+    }
+  };
 }
 
 module.exports = createMockComponent;

--- a/src/plugins/requireNativeComponent.js
+++ b/src/plugins/requireNativeComponent.js
@@ -4,12 +4,12 @@
 import React from 'react';
 
 function requireNativeComponent(viewName, componentInterface, extraConfig) {
-  return React.createClass({
-    displayName: viewName,
+  return class extends React.Component {
+    static displayName = viewName;
     render() {
       return null;
-    },
-  });
+    }
+  };
 }
 
 module.exports = requireNativeComponent;

--- a/src/propTypes/EdgeInsetsPropType.js
+++ b/src/propTypes/EdgeInsetsPropType.js
@@ -1,9 +1,7 @@
 /**
  * https://github.com/facebook/react-native/blob/master/Libraries/StyleSheet/EdgeInsetsPropType.js
  */
-import React from 'react';
-
-const { PropTypes } = React;
+import PropTypes from 'prop-types';
 
 const EdgeInsetsPropType = PropTypes.shape({
   top: PropTypes.number,

--- a/src/propTypes/ImageStylePropTypes.js
+++ b/src/propTypes/ImageStylePropTypes.js
@@ -1,14 +1,13 @@
 /**
  * https://github.com/facebook/react-native/blob/master/Libraries/Image/ImageStylePropTypes.js
  */
-import React from 'react';
 import ColorPropType from './ColorPropType';
 import TransformPropTypes from './TransformPropTypes';
 import ShadowPropTypesIOS from './ShadowPropTypesIOS';
 import LayoutPropTypes from './LayoutPropTypes';
 import ImageResizeMode from './ImageResizeMode';
 
-const { PropTypes } = React;
+import PropTypes from 'prop-types';
 
 const ImageStylePropTypes = {
   ...LayoutPropTypes,

--- a/src/propTypes/LayoutPropTypes.js
+++ b/src/propTypes/LayoutPropTypes.js
@@ -1,9 +1,7 @@
 /**
  * https://github.com/facebook/react-native/blob/master/Libraries/StyleSheet/LayoutPropTypes.js
  */
-import React from 'react';
-
-const { PropTypes } = React;
+import PropTypes from 'prop-types';
 
 /**
  * React Native's layout system is based on Flexbox and is powered both

--- a/src/propTypes/PointPropType.js
+++ b/src/propTypes/PointPropType.js
@@ -1,9 +1,7 @@
 /**
  * https://github.com/facebook/react-native/blob/master/Libraries/StyleSheet/PointPropType.js
  */
-import React from 'react';
-
-const { PropTypes } = React;
+import PropTypes from 'prop-types';
 
 const PointPropType = PropTypes.shape({
   x: PropTypes.number,

--- a/src/propTypes/ShadowPropTypesIOS.js
+++ b/src/propTypes/ShadowPropTypesIOS.js
@@ -1,7 +1,6 @@
-import React from 'react';
 import ColorPropType from './ColorPropType';
 
-const { PropTypes } = React;
+import PropTypes from 'prop-types';
 
 const ShadowPropTypesIOS = {
   /**

--- a/src/propTypes/StyleSheetPropType.js
+++ b/src/propTypes/StyleSheetPropType.js
@@ -1,10 +1,9 @@
 /**
  * https://github.com/facebook/react-native/blob/master/Libraries/StyleSheet/StyleSheetPropType.js
  */
-import React from 'react';
 import flattenStyle from './flattenStyle';
 
-const { PropTypes } = React;
+import PropTypes from 'prop-types';
 
 function StyleSheetPropType(shape) {
   const shapePropType = PropTypes.shape(shape);

--- a/src/propTypes/TextStylePropTypes.js
+++ b/src/propTypes/TextStylePropTypes.js
@@ -1,11 +1,10 @@
 /**
  * https://github.com/facebook/react-native/blob/master/Libraries/Text/TextStylePropTypes.js
  */
-import React from 'react';
 import ColorPropType from './ColorPropType';
 import ViewStylePropTypes from './ViewStylePropTypes';
 
-const { PropTypes } = React;
+import PropTypes from 'prop-types';
 
 // TODO: use spread instead of Object.assign/create after #6560135 is fixed
 const TextStylePropTypes = Object.assign(Object.create(ViewStylePropTypes), {

--- a/src/propTypes/TransformPropTypes.js
+++ b/src/propTypes/TransformPropTypes.js
@@ -1,9 +1,7 @@
 /**
  * https://github.com/facebook/react-native/blob/master/Libraries/StyleSheet/TransformPropTypes.js
  */
-import React from 'react';
-
-const { PropTypes } = React;
+import PropTypes from 'prop-types';
 
 const arrayOfNumberPropType = PropTypes.arrayOf(PropTypes.number);
 

--- a/src/propTypes/ViewPropTypes.js
+++ b/src/propTypes/ViewPropTypes.js
@@ -2,7 +2,6 @@
  * https://github.com/facebook/react-native/blob/master/Libraries/Components/View/ViewPropTypes.js
  */
 
-import React from 'react';
 import EdgeInsetsPropType from './EdgeInsetsPropType';
 import styleSheetPropType from './StyleSheetPropType';
 import ViewStylePropTypes from './ViewStylePropTypes';
@@ -10,7 +9,7 @@ import { AccessibilityComponentTypes, AccessibilityTraits } from '../components/
 
 const stylePropType = styleSheetPropType(ViewStylePropTypes);
 
-const { PropTypes } = React;
+import PropTypes from 'prop-types';
 
 const ViewPropTypes = {
   /**

--- a/src/propTypes/ViewStylePropTypes.js
+++ b/src/propTypes/ViewStylePropTypes.js
@@ -1,13 +1,12 @@
 /**
  * https://github.com/facebook/react-native/blob/master/Libraries/Components/View/ViewStylePropTypes.js
  */
-import React from 'react';
 import ColorPropType from './ColorPropType';
 import LayoutPropTypes from './LayoutPropTypes';
 import ShadowPropTypesIOS from './ShadowPropTypesIOS';
 import TransformPropTypes from './TransformPropTypes';
 
-const { PropTypes } = React;
+import PropTypes from 'prop-types';
 
 /**
  * Warning: Some of these properties may not be supported in all releases.


### PR DESCRIPTION
Changes `createClass` calls to equivalent ES6 syntax, bumps `react`, `react-native`, `react-dom` and changes `React.PropTypes` for proptypes imported from `prop-types`.