### PR TITLE
Update to Support React 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "react-addons-create-fragment": "^15.4.0",
     "react-addons-perf": "^15.4.0",
     "react-addons-pure-render-mixin": "^15.4.0",
-    "react-addons-test-utils": "^15.4.0",
     "react-addons-update": "^15.4.0",
     "react-dom": "^15.4.0",
     "react-timer-mixin": "^0.13.3",

--- a/package.json
+++ b/package.json
@@ -46,13 +46,10 @@
   },
   "dependencies": {
     "cubic-bezier": "^0.1.2",
+    "immutability-helper": "^2.6.4",
     "invariant": "^2.2.1",
     "keymirror": "^0.1.1",
     "raf": "^3.2.0",
-    "react-addons-create-fragment": "^16.0.0-alpha.3",
-    "react-addons-perf": "^16.0.0-alpha.3",
-    "react-addons-pure-render-mixin": "^16.0.0-alpha.3",
-    "react-addons-update": "^16.0.0-alpha.3",
     "react-dom": "^16.0.0",
     "react-timer-mixin": "^0.13.3",
     "warning": "^2.1.0"

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "keymirror": "^0.1.1",
     "raf": "^3.2.0",
     "react-dom": "^16.0.0",
+    "react-test-renderer": "^16.2.0",
     "react-timer-mixin": "^0.13.3",
     "warning": "^2.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -41,19 +41,19 @@
     "eslint-plugin-react": "5.1.1",
     "eslint-plugin-react-native": "1.0.2",
     "mocha": "2.5.3",
-    "react": "^15.4.0",
-    "react-native": "^0.38.0"
+    "react": "^16.0.0",
+    "react-native": "^0.50.0"
   },
   "dependencies": {
     "cubic-bezier": "^0.1.2",
     "invariant": "^2.2.1",
     "keymirror": "^0.1.1",
     "raf": "^3.2.0",
-    "react-addons-create-fragment": "^15.4.0",
-    "react-addons-perf": "^15.4.0",
-    "react-addons-pure-render-mixin": "^15.4.0",
-    "react-addons-update": "^15.4.0",
-    "react-dom": "^15.4.0",
+    "react-addons-create-fragment": "^16.0.0-alpha.3",
+    "react-addons-perf": "^16.0.0-alpha.3",
+    "react-addons-pure-render-mixin": "^16.0.0-alpha.3",
+    "react-addons-update": "^16.0.0-alpha.3",
+    "react-dom": "^16.0.0",
     "react-timer-mixin": "^0.13.3",
     "warning": "^2.1.0"
   },

--- a/src/Libraries/NavigationExperimental/NavigationPropTypes.js
+++ b/src/Libraries/NavigationExperimental/NavigationPropTypes.js
@@ -1,8 +1,7 @@
 class Animated {}
 
 import React from 'react';
-
-const { PropTypes } = React;
+import PropTypes from 'prop-types';
 
 /* NavigationAction */
 const action = PropTypes.shape({

--- a/src/Libraries/NavigationExperimental/NavigationPropTypes.js
+++ b/src/Libraries/NavigationExperimental/NavigationPropTypes.js
@@ -1,6 +1,5 @@
 class Animated {}
 
-import React from 'react';
 import PropTypes from 'prop-types';
 
 /* NavigationAction */

--- a/src/api/CameraRoll.js
+++ b/src/api/CameraRoll.js
@@ -1,5 +1,4 @@
 import invariant from 'invariant';
-import React from 'react';
 import CameraRollManager from '../NativeModules/CameraRollManager';
 import PropTypes from 'prop-types';
 

--- a/src/api/CameraRoll.js
+++ b/src/api/CameraRoll.js
@@ -1,8 +1,7 @@
 import invariant from 'invariant';
 import React from 'react';
 import CameraRollManager from '../NativeModules/CameraRollManager';
-
-const { PropTypes } = React;
+import PropTypes from 'prop-types';
 
 const GROUP_TYPES_OPTIONS = [
   'Album',

--- a/src/api/LayoutAnimation.js
+++ b/src/api/LayoutAnimation.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import UIManager from '../NativeModules/UIManager';
 import keyMirror from 'keymirror';
 import PropTypes from 'prop-types';

--- a/src/api/LayoutAnimation.js
+++ b/src/api/LayoutAnimation.js
@@ -1,8 +1,7 @@
 import React from 'react';
 import UIManager from '../NativeModules/UIManager';
 import keyMirror from 'keymirror';
-
-const { PropTypes } = React;
+import PropTypes from 'prop-types';
 
 const TypesEnum = {
   spring: true,

--- a/src/components/ActivityIndicator.js
+++ b/src/components/ActivityIndicator.js
@@ -1,7 +1,6 @@
 /**
  * https://github.com/facebook/react-native/blob/master/Libraries/Components/ActivityIndicator/ActivityIndicator.js
  */
-import React from 'react';
 import NativeMethodsMixin from '../mixins/NativeMethodsMixin';
 import View from './View';
 import ColorPropType from '../propTypes/ColorPropType';

--- a/src/components/ActivityIndicator.js
+++ b/src/components/ActivityIndicator.js
@@ -5,10 +5,10 @@ import React from 'react';
 import NativeMethodsMixin from '../mixins/NativeMethodsMixin';
 import View from './View';
 import ColorPropType from '../propTypes/ColorPropType';
+import PropTypes from 'prop-types';
+import createReactClass from 'create-react-class';
 
-const { PropTypes } = React;
-
-const ActivityIndicator = React.createClass({
+const ActivityIndicator = createReactClass({
   propTypes: {
     ...View.propTypes,
     /**

--- a/src/components/ActivityIndicatorIOS.js
+++ b/src/components/ActivityIndicatorIOS.js
@@ -1,7 +1,6 @@
 /**
  * https://github.com/facebook/react-native/blob/master/Libraries/Components/ActivityIndicator/ActivityIndicatorIOS.ios.js
  */
-import React from 'react';
 import NativeMethodsMixin from '../mixins/NativeMethodsMixin';
 import View from './View';
 import PropTypes from 'prop-types';

--- a/src/components/ActivityIndicatorIOS.js
+++ b/src/components/ActivityIndicatorIOS.js
@@ -4,10 +4,10 @@
 import React from 'react';
 import NativeMethodsMixin from '../mixins/NativeMethodsMixin';
 import View from './View';
+import PropTypes from 'prop-types';
+import createReactClass from 'create-react-class';
 
-const { PropTypes } = React;
-
-const ActivityIndicatorIOS = React.createClass({
+const ActivityIndicatorIOS = createReactClass({
   propTypes: {
     ...View.propTypes,
     /**

--- a/src/components/DrawerLayoutAndroid.js
+++ b/src/components/DrawerLayoutAndroid.js
@@ -8,7 +8,7 @@ import UIManager from '../NativeModules/UIManager';
 import ColorPropType from '../propTypes/ColorPropType';
 import createReactClass from 'create-react-class';
 
-const ReactPropTypes = React.PropTypes;
+const ReactPropTypes = require('prop-types');
 const DrawerConsts = UIManager.AndroidDrawerLayout.Constants;
 
 const DrawerLayoutAndroid = createReactClass({

--- a/src/components/DrawerLayoutAndroid.js
+++ b/src/components/DrawerLayoutAndroid.js
@@ -1,7 +1,6 @@
 /**
  *https://github.com/facebook/react-native/blob/master/Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.android.js
  */
-import React from 'react';
 import NativeMethodsMixin from '../mixins/NativeMethodsMixin';
 import View from './View';
 import UIManager from '../NativeModules/UIManager';

--- a/src/components/DrawerLayoutAndroid.js
+++ b/src/components/DrawerLayoutAndroid.js
@@ -6,11 +6,12 @@ import NativeMethodsMixin from '../mixins/NativeMethodsMixin';
 import View from './View';
 import UIManager from '../NativeModules/UIManager';
 import ColorPropType from '../propTypes/ColorPropType';
+import createReactClass from 'create-react-class';
 
 const ReactPropTypes = React.PropTypes;
 const DrawerConsts = UIManager.AndroidDrawerLayout.Constants;
 
-const DrawerLayoutAndroid = React.createClass({
+const DrawerLayoutAndroid = createReactClass({
 
   propTypes: {
     ...View.propTypes,

--- a/src/components/Image.js
+++ b/src/components/Image.js
@@ -1,7 +1,6 @@
 /**
  * https://github.com/facebook/react-native/blob/master/Libraries/Image/Image.ios.js
  */
-import React from 'react';
 import styleSheetPropType from '../propTypes/StyleSheetPropType';
 import NativeMethodsMixin from '../mixins/NativeMethodsMixin';
 import EdgeInsetsPropType from '../propTypes/EdgeInsetsPropType';

--- a/src/components/Image.js
+++ b/src/components/Image.js
@@ -7,10 +7,10 @@ import NativeMethodsMixin from '../mixins/NativeMethodsMixin';
 import EdgeInsetsPropType from '../propTypes/EdgeInsetsPropType';
 import ImageStylePropTypes from '../propTypes/ImageStylePropTypes';
 import ImageResizeMode from '../propTypes/ImageResizeMode';
+import PropTypes from 'prop-types';
+import createReactClass from 'create-react-class';
 
-const { PropTypes } = React;
-
-const Image = React.createClass({
+const Image = createReactClass({
   propTypes: {
     style: styleSheetPropType(ImageStylePropTypes),
     /**

--- a/src/components/ListView.js
+++ b/src/components/ListView.js
@@ -3,12 +3,12 @@ import ScrollResponder from '../mixins/ScrollResponder';
 import TimerMixin from 'react-timer-mixin';
 import ScrollView from './ScrollView';
 import ListViewDataSource from '../api/ListViewDataSource';
+import PropTypes from 'prop-types';
+import createReactClass from 'create-react-class';
 
-const { PropTypes } = React;
 const SCROLLVIEW_REF = 'listviewscroll';
 
-
-const ListView = React.createClass({
+const ListView = createReactClass({
   propTypes: {
     ...ScrollView.propTypes,
 

--- a/src/components/ListView.js
+++ b/src/components/ListView.js
@@ -80,12 +80,12 @@ const ListView = createReactClass({
      * A function that returns the scrollable component in which the list rows
      * are rendered. Defaults to returning a ScrollView with the given props.
      */
-    renderScrollComponent: React.PropTypes.func.isRequired,
+    renderScrollComponent: PropTypes.func.isRequired,
     /**
      * How early to start rendering rows before they come on screen, in
      * pixels.
      */
-    scrollRenderAheadDistance: React.PropTypes.number,
+    scrollRenderAheadDistance: PropTypes.number,
     /**
      * (visibleRows, changedRows) => void
      *
@@ -95,13 +95,13 @@ const ListView = createReactClass({
      * that have changed their visibility, with true indicating visible, and
      * false indicating the view has moved out of view.
      */
-    onChangeVisibleRows: React.PropTypes.func,
+    onChangeVisibleRows: PropTypes.func,
     /**
      * A performance optimization for improving scroll perf of
      * large lists, used in conjunction with overflow: 'hidden' on the row
      * containers.  This is enabled by default.
      */
-    removeClippedSubviews: React.PropTypes.bool,
+    removeClippedSubviews: PropTypes.bool,
     /**
      * An array of child indices determining which children get docked to the
      * top of the screen when scrolling. For example, passing

--- a/src/components/Navigator.js
+++ b/src/components/Navigator.js
@@ -9,7 +9,7 @@ const NavigatorSceneConfigType = PropTypes.shape({
   springFriction: PropTypes.number,
   springTension: PropTypes.number,
   defaultTransitionVelocity: PropTypes.number,
-  animationInterpolators: React.PropTypes.object,
+  animationInterpolators: PropTypes.object,
 });
 
 const NavigatorSceneConfigs = {

--- a/src/components/Navigator.js
+++ b/src/components/Navigator.js
@@ -1,6 +1,7 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
 import createMockComponent from './createMockComponent';
 import View from './View';
+import PropTypes from 'prop-types';
 import createReactClass from 'create-react-class';
 
 const NavigatorSceneConfigType = PropTypes.shape({

--- a/src/components/Navigator.js
+++ b/src/components/Navigator.js
@@ -1,6 +1,7 @@
 import React, { PropTypes } from 'react';
 import createMockComponent from './createMockComponent';
 import View from './View';
+import createReactClass from 'create-react-class';
 
 const NavigatorSceneConfigType = PropTypes.shape({
   gestures: PropTypes.object,
@@ -23,7 +24,7 @@ const NavigatorSceneConfigs = {
   VerticalDownSwipeJump: NavigatorSceneConfigType
 };
 
-const Navigator = React.createClass({
+const Navigator = createReactClass({
   propTypes: {
     /**
      * Optional function that allows configuration about scene animations and

--- a/src/components/Navigator.js
+++ b/src/components/Navigator.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import createMockComponent from './createMockComponent';
 import View from './View';
 import PropTypes from 'prop-types';

--- a/src/components/Picker.js
+++ b/src/components/Picker.js
@@ -1,10 +1,11 @@
 import React from 'react';
 import createMockComponent from './createMockComponent';
 import createReactClass from 'create-react-class';
+import PropTypes from 'prop-types';
 
 const Picker = createReactClass({
   propTypes: {
-    children: React.PropTypes.node
+    children: PropTypes.node
   },
   statics: {
     Item: createMockComponent('Picker.Item')

--- a/src/components/Picker.js
+++ b/src/components/Picker.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import createMockComponent from './createMockComponent';
 import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';

--- a/src/components/Picker.js
+++ b/src/components/Picker.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import createMockComponent from './createMockComponent';
+import createReactClass from 'create-react-class';
 
-const Picker = React.createClass({
+const Picker = createReactClass({
   propTypes: {
     children: React.PropTypes.node
   },

--- a/src/components/ScrollView.js
+++ b/src/components/ScrollView.js
@@ -6,13 +6,13 @@ import View from './View';
 import ViewStylePropTypes from '../propTypes/ViewStylePropTypes';
 import ScrollViewManager from '../NativeModules/ScrollViewManager';
 import styleSheetPropType from '../propTypes/StyleSheetPropType';
-
-const { PropTypes } = React;
+import PropTypes from 'prop-types';
+import createReactClass from 'create-react-class';
 
 const SCROLLVIEW = 'ScrollView';
 const INNERVIEW = 'InnerScrollView';
 
-const ScrollView = React.createClass({
+const ScrollView = createReactClass({
   propTypes: {
     ...View.propTypes,
     /**

--- a/src/components/StatusBar.js
+++ b/src/components/StatusBar.js
@@ -4,6 +4,7 @@
 import React from 'react';
 import ColorPropType from '../propTypes/ColorPropType';
 import createReactClass from 'create-react-class';
+import PropTypes from 'prop-types';
 
 let _backgroundColor = '';
 let _barStyle = {};
@@ -13,13 +14,13 @@ let _translucent = false;
 
 const StatusBar = createReactClass({
   propTypes: {
-    animated: React.PropTypes.bool,
-    barStyle: React.PropTypes.oneOf(['default', 'light-content']),
+    animated: PropTypes.bool,
+    barStyle: PropTypes.oneOf(['default', 'light-content']),
     backgroundColor: ColorPropType,
-    hidden: React.PropTypes.bool,
-    networkActivityIndicatorVisible: React.PropTypes.bool,
-    showHideTransition: React.PropTypes.oneOf(['fade', 'slide']),
-    translucent: React.PropTypes.bool
+    hidden: PropTypes.bool,
+    networkActivityIndicatorVisible: PropTypes.bool,
+    showHideTransition: PropTypes.oneOf(['fade', 'slide']),
+    translucent: PropTypes.bool
   },
 
   statics: {

--- a/src/components/StatusBar.js
+++ b/src/components/StatusBar.js
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 import ColorPropType from '../propTypes/ColorPropType';
-
+import createReactClass from 'create-react-class';
 
 let _backgroundColor = '';
 let _barStyle = {};
@@ -11,7 +11,7 @@ let _hidden = false;
 let _networkActivityIndicatorVisible = false;
 let _translucent = false;
 
-const StatusBar = React.createClass({
+const StatusBar = createReactClass({
   propTypes: {
     animated: React.PropTypes.bool,
     barStyle: React.PropTypes.oneOf(['default', 'light-content']),

--- a/src/components/StatusBar.js
+++ b/src/components/StatusBar.js
@@ -1,7 +1,6 @@
 /**
  * https://github.com/facebook/react-native/blob/master/Libraries/Components/StatusBar/StatusBar.js
  */
-import React from 'react';
 import ColorPropType from '../propTypes/ColorPropType';
 import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';

--- a/src/components/TabBarIOS.js
+++ b/src/components/TabBarIOS.js
@@ -1,10 +1,11 @@
 import React from 'react';
 import createMockComponent from './createMockComponent';
 import createReactClass from 'create-react-class';
+import PropTypes from 'prop-types';
 
 const TabBarIOS = createReactClass({
   propTypes: {
-    children: React.PropTypes.node
+    children: PropTypes.node
   },
   statics: {
     Item: createMockComponent('TabBarIOS.Item')

--- a/src/components/TabBarIOS.js
+++ b/src/components/TabBarIOS.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import createMockComponent from './createMockComponent';
+import createReactClass from 'create-react-class';
 
-const TabBarIOS = React.createClass({
+const TabBarIOS = createReactClass({
   propTypes: {
     children: React.PropTypes.node
   },

--- a/src/components/TabBarIOS.js
+++ b/src/components/TabBarIOS.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import createMockComponent from './createMockComponent';
 import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';

--- a/src/components/Text.js
+++ b/src/components/Text.js
@@ -5,10 +5,11 @@ import React from 'react';
 import styleSheetPropType from '../propTypes/StyleSheetPropType';
 import TextStylePropTypes from '../propTypes/TextStylePropTypes';
 import NativeMethodsMixin from '../mixins/NativeMethodsMixin';
+import createReactClass from 'create-react-class';
 
 const stylePropType = styleSheetPropType(TextStylePropTypes);
 
-const Text = React.createClass({
+const Text = createReactClass({
   propTypes: {
     /**
      * Used to truncate the text with an ellipsis after computing the text

--- a/src/components/Text.js
+++ b/src/components/Text.js
@@ -6,6 +6,7 @@ import styleSheetPropType from '../propTypes/StyleSheetPropType';
 import TextStylePropTypes from '../propTypes/TextStylePropTypes';
 import NativeMethodsMixin from '../mixins/NativeMethodsMixin';
 import createReactClass from 'create-react-class';
+import PropTypes from 'prop-types';
 
 const stylePropType = styleSheetPropType(TextStylePropTypes);
 
@@ -16,33 +17,33 @@ const Text = createReactClass({
      * layout, including line wrapping, such that the total number of lines
      * does not exceed this number.
      */
-    numberOfLines: React.PropTypes.number,
+    numberOfLines: PropTypes.number,
     /**
      * Invoked on mount and layout changes with
      *
      *   `{nativeEvent: {layout: {x, y, width, height}}}`
      */
-    onLayout: React.PropTypes.func,
+    onLayout: PropTypes.func,
     /**
      * This function is called on press.
      */
-    onPress: React.PropTypes.func,
+    onPress: PropTypes.func,
     /**
      * When true, no visual change is made when text is pressed down. By
      * default, a gray oval highlights the text on press down.
      * @platform ios
      */
-    suppressHighlighting: React.PropTypes.bool,
+    suppressHighlighting: PropTypes.bool,
     style: stylePropType,
     /**
      * Used to locate this view in end-to-end tests.
      */
-    testID: React.PropTypes.string,
+    testID: PropTypes.string,
     /**
      * Specifies should fonts scale to respect Text Size accessibility setting on iOS.
      * @platform ios
      */
-    allowFontScaling: React.PropTypes.bool,
+    allowFontScaling: PropTypes.bool,
   },
   mixins: [NativeMethodsMixin],
 

--- a/src/components/Text.js
+++ b/src/components/Text.js
@@ -1,7 +1,6 @@
 /**
  * https://github.com/facebook/react-native/blob/master/Libraries/Text/Text.js
  */
-import React from 'react';
 import styleSheetPropType from '../propTypes/StyleSheetPropType';
 import TextStylePropTypes from '../propTypes/TextStylePropTypes';
 import NativeMethodsMixin from '../mixins/NativeMethodsMixin';

--- a/src/components/TextInput.js
+++ b/src/components/TextInput.js
@@ -4,10 +4,10 @@ import TimerMixin from 'react-timer-mixin';
 import NativeMethodsMixin from '../mixins/NativeMethodsMixin';
 import View from './View';
 import Text from './Text';
+import PropTypes from 'prop-types';
+import createReactClass from 'create-react-class';
 
-const { PropTypes } = React;
-
-const TextInput = React.createClass({
+const TextInput = createReactClass({
   propTypes: {
     ...View.propTypes,
     /**

--- a/src/components/TouchableNativeFeedback.js
+++ b/src/components/TouchableNativeFeedback.js
@@ -2,12 +2,13 @@
 import React from 'react';
 import createReactClass from 'create-react-class';
 import TouchableWithoutFeedback from './TouchableWithoutFeedback';
+import PropTypes from 'prop-types';
 
 const TouchableNativeFeedback = createReactClass({
   propTypes: {
     ...TouchableWithoutFeedback.propTypes,
 
-    background: React.PropTypes.object
+    background: PropTypes.object
   },
   statics: {
     SelectableBackground() {},

--- a/src/components/TouchableNativeFeedback.js
+++ b/src/components/TouchableNativeFeedback.js
@@ -1,5 +1,3 @@
-
-import React from 'react';
 import createReactClass from 'create-react-class';
 import TouchableWithoutFeedback from './TouchableWithoutFeedback';
 import PropTypes from 'prop-types';

--- a/src/components/TouchableNativeFeedback.js
+++ b/src/components/TouchableNativeFeedback.js
@@ -1,9 +1,9 @@
 
 import React from 'react';
-
+import createReactClass from 'create-react-class';
 import TouchableWithoutFeedback from './TouchableWithoutFeedback';
 
-const TouchableNativeFeedback = React.createClass({
+const TouchableNativeFeedback = createReactClass({
   propTypes: {
     ...TouchableWithoutFeedback.propTypes,
 

--- a/src/components/TouchableOpacity.js
+++ b/src/components/TouchableOpacity.js
@@ -4,6 +4,7 @@
 import React from 'react';
 import createReactClass from 'create-react-class';
 import TouchableWithoutFeedback from './TouchableWithoutFeedback';
+import PropTypes from 'prop-types';
 
 const TouchableOpacity = createReactClass({
   propTypes: {
@@ -13,7 +14,7 @@ const TouchableOpacity = createReactClass({
      * Determines what the opacity of the wrapped view should be when touch is
      * active. Defaults to 0.2.
      */
-    activeOpacity: React.PropTypes.number,
+    activeOpacity: PropTypes.number,
   },
 
   render() {

--- a/src/components/TouchableOpacity.js
+++ b/src/components/TouchableOpacity.js
@@ -1,7 +1,6 @@
 /**
  * https://github.com/facebook/react-native/blob/master/Libraries/Components/Touchable/TouchableOpacity.js
  */
-import React from 'react';
 import createReactClass from 'create-react-class';
 import TouchableWithoutFeedback from './TouchableWithoutFeedback';
 import PropTypes from 'prop-types';

--- a/src/components/TouchableOpacity.js
+++ b/src/components/TouchableOpacity.js
@@ -2,10 +2,10 @@
  * https://github.com/facebook/react-native/blob/master/Libraries/Components/Touchable/TouchableOpacity.js
  */
 import React from 'react';
-
+import createReactClass from 'create-react-class';
 import TouchableWithoutFeedback from './TouchableWithoutFeedback';
 
-const TouchableOpacity = React.createClass({
+const TouchableOpacity = createReactClass({
   propTypes: {
     ...TouchableWithoutFeedback.propTypes,
 

--- a/src/components/TouchableWithoutFeedback.js
+++ b/src/components/TouchableWithoutFeedback.js
@@ -4,8 +4,9 @@
 import React from 'react';
 import EdgeInsetsPropType from '../propTypes/EdgeInsetsPropType';
 import View from './View';
+import createReactClass from 'create-react-class';
 
-const TouchableWithoutFeedback = React.createClass({
+const TouchableWithoutFeedback = createReactClass({
   propTypes: {
     accessible: React.PropTypes.bool,
     accessibilityComponentType: React.PropTypes.oneOf(View.AccessibilityComponentType),

--- a/src/components/TouchableWithoutFeedback.js
+++ b/src/components/TouchableWithoutFeedback.js
@@ -1,7 +1,6 @@
 /**
  * https://github.com/facebook/react-native/blob/master/Libraries/Components/Touchable/TouchableWithoutFeedback.js
  */
-import React from 'react';
 import EdgeInsetsPropType from '../propTypes/EdgeInsetsPropType';
 import View from './View';
 import createReactClass from 'create-react-class';

--- a/src/components/TouchableWithoutFeedback.js
+++ b/src/components/TouchableWithoutFeedback.js
@@ -5,47 +5,48 @@ import React from 'react';
 import EdgeInsetsPropType from '../propTypes/EdgeInsetsPropType';
 import View from './View';
 import createReactClass from 'create-react-class';
+import PropTypes from 'prop-types';
 
 const TouchableWithoutFeedback = createReactClass({
   propTypes: {
-    accessible: React.PropTypes.bool,
-    accessibilityComponentType: React.PropTypes.oneOf(View.AccessibilityComponentType),
-    accessibilityTraits: React.PropTypes.oneOfType([
-      React.PropTypes.oneOf(View.AccessibilityTraits),
-      React.PropTypes.arrayOf(React.PropTypes.oneOf(View.AccessibilityTraits)),
+    accessible: PropTypes.bool,
+    accessibilityComponentType: PropTypes.oneOf(View.AccessibilityComponentType),
+    accessibilityTraits: PropTypes.oneOfType([
+      PropTypes.oneOf(View.AccessibilityTraits),
+      PropTypes.arrayOf(PropTypes.oneOf(View.AccessibilityTraits)),
     ]),
     /**
      * If true, disable all interactions for this component.
      */
-    disabled: React.PropTypes.bool,
+    disabled: PropTypes.bool,
     /**
      * Called when the touch is released, but not if cancelled (e.g. by a scroll
      * that steals the responder lock).
      */
-    onPress: React.PropTypes.func,
-    onPressIn: React.PropTypes.func,
-    onPressOut: React.PropTypes.func,
+    onPress: PropTypes.func,
+    onPressIn: PropTypes.func,
+    onPressOut: PropTypes.func,
     /**
      * Invoked on mount and layout changes with
      *
      *   `{nativeEvent: {layout: {x, y, width, height}}}`
      */
-    onLayout: React.PropTypes.func,
+    onLayout: PropTypes.func,
 
-    onLongPress: React.PropTypes.func,
+    onLongPress: PropTypes.func,
 
     /**
      * Delay in ms, from the start of the touch, before onPressIn is called.
      */
-    delayPressIn: React.PropTypes.number,
+    delayPressIn: PropTypes.number,
     /**
      * Delay in ms, from the release of the touch, before onPressOut is called.
      */
-    delayPressOut: React.PropTypes.number,
+    delayPressOut: PropTypes.number,
     /**
      * Delay in ms, from onPressIn, before onLongPress is called.
      */
-    delayLongPress: React.PropTypes.number,
+    delayLongPress: PropTypes.number,
     /**
      * When the scroll view is disabled, this defines how far your touch may
      * move off of the button, before deactivating the button. Once deactivated,

--- a/src/components/View.js
+++ b/src/components/View.js
@@ -5,6 +5,7 @@ import React from 'react';
 import ViewAccessibility from './ViewAccessibility';
 import NativeMethodsMixin from '../mixins/NativeMethodsMixin';
 import ViewPropTypes from '../propTypes/ViewPropTypes';
+import createReactClass from 'create-react-class';
 
 const { AccessibilityTraits, AccessibilityComponentTypes } = ViewAccessibility;
 
@@ -20,7 +21,7 @@ const statics = {
   forceTouchAvailable,
 };
 
-const View = React.createClass({
+const View = createReactClass({
   propTypes: ViewPropTypes,
 
   mixins: [NativeMethodsMixin],

--- a/src/components/View.js
+++ b/src/components/View.js
@@ -1,7 +1,6 @@
 /**
  * https://github.com/facebook/react-native/blob/master/Libraries/Components/View/View.js
  */
-import React from 'react';
 import ViewAccessibility from './ViewAccessibility';
 import NativeMethodsMixin from '../mixins/NativeMethodsMixin';
 import ViewPropTypes from '../propTypes/ViewPropTypes';

--- a/src/components/WebView.js
+++ b/src/components/WebView.js
@@ -3,8 +3,8 @@ import React from 'react';
 import View from './View';
 import ScrollView from './ScrollView';
 import WebViewManager from '../NativeModules/WebViewManager';
-
-const { PropTypes } = React;
+import PropTypes from 'prop-types';
+import createReactClass from 'create-react-class';
 
 const RCT_WEBVIEW_REF = 'webview';
 
@@ -19,7 +19,7 @@ const NavigationType = {
 
 const JSNavigationScheme = WebViewManager.JSNavigationScheme;
 
-const WebView = React.createClass({
+const WebView = createReactClass({
   propTypes: {
     ...View.propTypes,
     url: PropTypes.string,

--- a/src/components/createMockComponent.js
+++ b/src/components/createMockComponent.js
@@ -1,7 +1,8 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 
 function createMockComponent(displayName) {
-  return React.createClass({
+  return createReactClass({
     displayName,
     render() {
       return null;

--- a/src/components/createMockComponent.js
+++ b/src/components/createMockComponent.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import createReactClass from 'create-react-class';
 
 function createMockComponent(displayName) {

--- a/src/plugins/requireNativeComponent.js
+++ b/src/plugins/requireNativeComponent.js
@@ -1,7 +1,6 @@
 /**
  * https://github.com/facebook/react-native/blob/master/Libraries/ReactIOS/requireNativeComponent.js
  */
-import React from 'react';
 import createReactClass from 'create-react-class';
 
 function requireNativeComponent(viewName, componentInterface, extraConfig) {

--- a/src/plugins/requireNativeComponent.js
+++ b/src/plugins/requireNativeComponent.js
@@ -2,9 +2,10 @@
  * https://github.com/facebook/react-native/blob/master/Libraries/ReactIOS/requireNativeComponent.js
  */
 import React from 'react';
+import createReactClass from 'create-react-class';
 
 function requireNativeComponent(viewName, componentInterface, extraConfig) {
-  return React.createClass({
+  return createReactClass({
     displayName: viewName,
     render() {
       return null;

--- a/src/propTypes/EdgeInsetsPropType.js
+++ b/src/propTypes/EdgeInsetsPropType.js
@@ -2,8 +2,7 @@
  * https://github.com/facebook/react-native/blob/master/Libraries/StyleSheet/EdgeInsetsPropType.js
  */
 import React from 'react';
-
-const { PropTypes } = React;
+import PropTypes from 'prop-types';
 
 const EdgeInsetsPropType = PropTypes.shape({
   top: PropTypes.number,

--- a/src/propTypes/EdgeInsetsPropType.js
+++ b/src/propTypes/EdgeInsetsPropType.js
@@ -1,7 +1,6 @@
 /**
  * https://github.com/facebook/react-native/blob/master/Libraries/StyleSheet/EdgeInsetsPropType.js
  */
-import React from 'react';
 import PropTypes from 'prop-types';
 
 const EdgeInsetsPropType = PropTypes.shape({

--- a/src/propTypes/ImageStylePropTypes.js
+++ b/src/propTypes/ImageStylePropTypes.js
@@ -7,8 +7,7 @@ import TransformPropTypes from './TransformPropTypes';
 import ShadowPropTypesIOS from './ShadowPropTypesIOS';
 import LayoutPropTypes from './LayoutPropTypes';
 import ImageResizeMode from './ImageResizeMode';
-
-const { PropTypes } = React;
+import PropTypes from 'prop-types';
 
 const ImageStylePropTypes = {
   ...LayoutPropTypes,

--- a/src/propTypes/ImageStylePropTypes.js
+++ b/src/propTypes/ImageStylePropTypes.js
@@ -1,7 +1,6 @@
 /**
  * https://github.com/facebook/react-native/blob/master/Libraries/Image/ImageStylePropTypes.js
  */
-import React from 'react';
 import ColorPropType from './ColorPropType';
 import TransformPropTypes from './TransformPropTypes';
 import ShadowPropTypesIOS from './ShadowPropTypesIOS';

--- a/src/propTypes/LayoutPropTypes.js
+++ b/src/propTypes/LayoutPropTypes.js
@@ -2,8 +2,7 @@
  * https://github.com/facebook/react-native/blob/master/Libraries/StyleSheet/LayoutPropTypes.js
  */
 import React from 'react';
-
-const { PropTypes } = React;
+import PropTypes from 'prop-types';
 
 /**
  * React Native's layout system is based on Flexbox and is powered both

--- a/src/propTypes/LayoutPropTypes.js
+++ b/src/propTypes/LayoutPropTypes.js
@@ -1,7 +1,6 @@
 /**
  * https://github.com/facebook/react-native/blob/master/Libraries/StyleSheet/LayoutPropTypes.js
  */
-import React from 'react';
 import PropTypes from 'prop-types';
 
 /**

--- a/src/propTypes/PointPropType.js
+++ b/src/propTypes/PointPropType.js
@@ -2,8 +2,7 @@
  * https://github.com/facebook/react-native/blob/master/Libraries/StyleSheet/PointPropType.js
  */
 import React from 'react';
-
-const { PropTypes } = React;
+import PropTypes from 'prop-types';
 
 const PointPropType = PropTypes.shape({
   x: PropTypes.number,

--- a/src/propTypes/PointPropType.js
+++ b/src/propTypes/PointPropType.js
@@ -1,7 +1,6 @@
 /**
  * https://github.com/facebook/react-native/blob/master/Libraries/StyleSheet/PointPropType.js
  */
-import React from 'react';
 import PropTypes from 'prop-types';
 
 const PointPropType = PropTypes.shape({

--- a/src/propTypes/ShadowPropTypesIOS.js
+++ b/src/propTypes/ShadowPropTypesIOS.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import ColorPropType from './ColorPropType';
-
-const { PropTypes } = React;
+import PropTypes from 'prop-types';
 
 const ShadowPropTypesIOS = {
   /**

--- a/src/propTypes/ShadowPropTypesIOS.js
+++ b/src/propTypes/ShadowPropTypesIOS.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import ColorPropType from './ColorPropType';
 import PropTypes from 'prop-types';
 

--- a/src/propTypes/StyleSheetPropType.js
+++ b/src/propTypes/StyleSheetPropType.js
@@ -3,8 +3,7 @@
  */
 import React from 'react';
 import flattenStyle from './flattenStyle';
-
-const { PropTypes } = React;
+import PropTypes from 'prop-types';
 
 function StyleSheetPropType(shape) {
   const shapePropType = PropTypes.shape(shape);

--- a/src/propTypes/StyleSheetPropType.js
+++ b/src/propTypes/StyleSheetPropType.js
@@ -1,7 +1,6 @@
 /**
  * https://github.com/facebook/react-native/blob/master/Libraries/StyleSheet/StyleSheetPropType.js
  */
-import React from 'react';
 import flattenStyle from './flattenStyle';
 import PropTypes from 'prop-types';
 

--- a/src/propTypes/TextStylePropTypes.js
+++ b/src/propTypes/TextStylePropTypes.js
@@ -4,8 +4,7 @@
 import React from 'react';
 import ColorPropType from './ColorPropType';
 import ViewStylePropTypes from './ViewStylePropTypes';
-
-const { PropTypes } = React;
+import PropTypes from 'prop-types';
 
 // TODO: use spread instead of Object.assign/create after #6560135 is fixed
 const TextStylePropTypes = Object.assign(Object.create(ViewStylePropTypes), {

--- a/src/propTypes/TextStylePropTypes.js
+++ b/src/propTypes/TextStylePropTypes.js
@@ -1,7 +1,6 @@
 /**
  * https://github.com/facebook/react-native/blob/master/Libraries/Text/TextStylePropTypes.js
  */
-import React from 'react';
 import ColorPropType from './ColorPropType';
 import ViewStylePropTypes from './ViewStylePropTypes';
 import PropTypes from 'prop-types';

--- a/src/propTypes/TransformPropTypes.js
+++ b/src/propTypes/TransformPropTypes.js
@@ -2,8 +2,7 @@
  * https://github.com/facebook/react-native/blob/master/Libraries/StyleSheet/TransformPropTypes.js
  */
 import React from 'react';
-
-const { PropTypes } = React;
+import PropTypes from 'prop-types';
 
 const arrayOfNumberPropType = PropTypes.arrayOf(PropTypes.number);
 

--- a/src/propTypes/TransformPropTypes.js
+++ b/src/propTypes/TransformPropTypes.js
@@ -1,7 +1,6 @@
 /**
  * https://github.com/facebook/react-native/blob/master/Libraries/StyleSheet/TransformPropTypes.js
  */
-import React from 'react';
 import PropTypes from 'prop-types';
 
 const arrayOfNumberPropType = PropTypes.arrayOf(PropTypes.number);

--- a/src/propTypes/ViewPropTypes.js
+++ b/src/propTypes/ViewPropTypes.js
@@ -7,10 +7,9 @@ import EdgeInsetsPropType from './EdgeInsetsPropType';
 import styleSheetPropType from './StyleSheetPropType';
 import ViewStylePropTypes from './ViewStylePropTypes';
 import { AccessibilityComponentTypes, AccessibilityTraits } from '../components/ViewAccessibility';
+import PropTypes from 'prop-types';
 
 const stylePropType = styleSheetPropType(ViewStylePropTypes);
-
-const { PropTypes } = React;
 
 const ViewPropTypes = {
   /**

--- a/src/propTypes/ViewPropTypes.js
+++ b/src/propTypes/ViewPropTypes.js
@@ -1,8 +1,6 @@
 /**
  * https://github.com/facebook/react-native/blob/master/Libraries/Components/View/ViewPropTypes.js
  */
-
-import React from 'react';
 import EdgeInsetsPropType from './EdgeInsetsPropType';
 import styleSheetPropType from './StyleSheetPropType';
 import ViewStylePropTypes from './ViewStylePropTypes';

--- a/src/propTypes/ViewStylePropTypes.js
+++ b/src/propTypes/ViewStylePropTypes.js
@@ -6,8 +6,7 @@ import ColorPropType from './ColorPropType';
 import LayoutPropTypes from './LayoutPropTypes';
 import ShadowPropTypesIOS from './ShadowPropTypesIOS';
 import TransformPropTypes from './TransformPropTypes';
-
-const { PropTypes } = React;
+import PropTypes from 'prop-types';
 
 /**
  * Warning: Some of these properties may not be supported in all releases.

--- a/src/propTypes/ViewStylePropTypes.js
+++ b/src/propTypes/ViewStylePropTypes.js
@@ -1,7 +1,6 @@
 /**
  * https://github.com/facebook/react-native/blob/master/Libraries/Components/View/ViewStylePropTypes.js
  */
-import React from 'react';
 import ColorPropType from './ColorPropType';
 import LayoutPropTypes from './LayoutPropTypes';
 import ShadowPropTypesIOS from './ShadowPropTypesIOS';

--- a/src/react-native.js
+++ b/src/react-native.js
@@ -111,7 +111,7 @@ const ReactNativeAddons = {
   Perf: require('react-addons-perf'),
   PureRenderMixin: require('react-addons-pure-render-mixin'),
   TestModule: require('./NativeModules/TestModule'),
-  TestUtils: require('react-addons-test-utils'),
+  TestUtils: require('react-dom/test-utils'),
   // TODO(lmr): not sure where to find this
   // batchedUpdates: require('ReactUpdates').batchedUpdates, deprecated
   // cloneWithProps: require('react-addons-clone-with-props'), deprecated

--- a/src/react-native.js
+++ b/src/react-native.js
@@ -108,15 +108,15 @@ const ReactNative = {
 // See http://facebook.github.io/react/docs/addons.html
 const ReactNativeAddons = {
   // LinkedStateMixin: require('react-addons-linked-state-mixin') deprecated,
-  Perf: require('react-addons-perf'),
-  PureRenderMixin: require('react-addons-pure-render-mixin'),
+  // Perf: require('react-addons-perf'),
+  // PureRenderMixin: require('react-addons-pure-render-mixin'),
   TestModule: require('./NativeModules/TestModule'),
   TestUtils: require('react-dom/test-utils'),
   // TODO(lmr): not sure where to find this
   // batchedUpdates: require('ReactUpdates').batchedUpdates, deprecated
   // cloneWithProps: require('react-addons-clone-with-props'), deprecated
-  createFragment: require('react-addons-create-fragment'),
-  update: require('react-addons-update'),
+  // createFragment: require('react-addons-create-fragment'),
+  update: require('immutability-helper'),
 };
 
 Object.assign(ReactNative, React, { addons: ReactNativeAddons });

--- a/src/react-native.js
+++ b/src/react-native.js
@@ -111,7 +111,7 @@ const ReactNativeAddons = {
   // Perf: require('react-addons-perf'),
   // PureRenderMixin: require('react-addons-pure-render-mixin'),
   TestModule: require('./NativeModules/TestModule'),
-  TestUtils: require('react-dom/test-utils'),
+  TestUtils: require('react-test-renderer/shallow'),
   // TODO(lmr): not sure where to find this
   // batchedUpdates: require('ReactUpdates').batchedUpdates, deprecated
   // cloneWithProps: require('react-addons-clone-with-props'), deprecated

--- a/test/components/DrawerLayoutAndroid.js
+++ b/test/components/DrawerLayoutAndroid.js
@@ -2,7 +2,7 @@
 import React from 'react';
 import { DrawerLayoutAndroid } from '../../src/react-native';
 import { expect } from 'chai';
-import ReactTestUtils from 'react-addons-test-utils';
+import ReactTestUtils from 'react-dom/test-utils';
 
 describe('DrawerLayoutAndroid', () => {
   it('should render an empty DrawerLayoutAndroid', () => {

--- a/test/components/DrawerLayoutAndroid.js
+++ b/test/components/DrawerLayoutAndroid.js
@@ -2,12 +2,12 @@
 import React from 'react';
 import { DrawerLayoutAndroid } from '../../src/react-native';
 import { expect } from 'chai';
-import ReactTestUtils from 'react-dom/test-utils';
+import ShallowRenderer from 'react-test-renderer/shallow';
 
 describe('DrawerLayoutAndroid', () => {
   it('should render an empty DrawerLayoutAndroid', () => {
-    const renderer = ReactTestUtils.createRenderer();
-    const wrapper = renderer.getRenderOutput(<DrawerLayoutAndroid renderNavigationView={() => {}} />);
+    const renderer = new ShallowRenderer(<DrawerLayoutAndroid renderNavigationView={() => {}} />);
+    const wrapper = renderer.getRenderOutput();
     expect(wrapper).to.be.null;
   });
 


### PR DESCRIPTION
1. Update react to v16.0.0, and react-native to v0.50.0.
2. Replace React.PropTypes by 'prop-types'.
3. Replace React.createClass by 'create-react-class'.
4. Replace 'react-addons-test-utils' by 'react-dom/test-utils'.
5. Remove some addons: react-addons-create-fragment, react-addons-perf, react-addons-pure-render-mixin (no longer supported and moved into React) to avoid crash.
6. Replace react-addons-update by immutability-helper.