### PR TITLE
Enable nodir for glob.sync

### DIFF
--- a/src/haste.js
+++ b/src/haste.js
@@ -26,7 +26,9 @@ var data = {
   version: require('./react-native-version')
 };
 
-var files = glob.sync(path.join(PROJECT_NODE_MODULES, '**/*.js'));
+var files = glob.sync(path.join(PROJECT_NODE_MODULES, '**/*.js'), {
+  nodir: true
+});
 
 _.forEach(files, function (file) {
   var matches = providesRegex.exec(fs.readFileSync(file).toString());


### PR DESCRIPTION
This is to prevent the following error `Error: EISDIR: illegal operation on a directory, read`. Where certain packages end with `.js` such as https://github.com/indutny/asn1.js.

The following library has such dependencies which made me found this error:
└─┬ @storybook/react-native@3.3.14
  └─┬ webpack@3.11.0
    └─┬ node-libs-browser@2.1.0
      └─┬ crypto-browserify@3.12.0
        └─┬ browserify-sign@4.0.4
          └─┬ parse-asn1@5.1.0
            └── asn1.js@4.10.1